### PR TITLE
Define and test ny open reversal strategy

### DIFF
--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -72,6 +72,12 @@ showDebug    = input.bool(false, "Show debug plots")
 showAsiaBox  = input.bool(true, "Show Asia box (pink)")
 showLondonBox= input.bool(true, "Show London box (blue)")
 showWeeklyHL = input.bool(true, "Show Weekly High/Low")
+asiaColor    = input.color(color.fuchsia, "Asia color")
+asiaFillT    = input.int(85, "Asia box transparency", minval=0, maxval=100)
+asiaLineW    = input.int(1, "Asia line width", minval=1, maxval=5)
+londonColor  = input.color(color.blue, "London color")
+londonFillT  = input.int(85, "London box transparency", minval=0, maxval=100)
+londonLineW  = input.int(1, "London line width", minval=1, maxval=5)
 
 // ==========================
 // Time helpers (ET)
@@ -275,10 +281,10 @@ if inAsia and not inAsia[1]
     asiaHigh := high
     asiaLow  := low
     if showAsiaBox
-        asiaBox := box.new(asiaT0, asiaHigh, asiaT0, asiaLow, xloc=xloc.bar_time, bgcolor=color.new(color.fuchsia, 85), border_color=color.fuchsia)
+        asiaBox := box.new(asiaT0, asiaHigh, asiaT0, asiaLow, xloc=xloc.bar_time, bgcolor=color.new(asiaColor, asiaFillT), border_color=asiaColor)
     // create lines anchored at session start
-    asiaHiLn := line.new(asiaT0, asiaHigh, time, asiaHigh, xloc=xloc.bar_time, extend=extend.none, color=color.fuchsia, width=1)
-    asiaLoLn := line.new(asiaT0, asiaLow,  time, asiaLow,  xloc=xloc.bar_time, extend=extend.none, color=color.fuchsia, width=1)
+    asiaHiLn := line.new(asiaT0, asiaHigh, time, asiaHigh, xloc=xloc.bar_time, extend=extend.none, color=asiaColor, width=asiaLineW)
+    asiaLoLn := line.new(asiaT0, asiaLow,  time, asiaLow,  xloc=xloc.bar_time, extend=extend.none, color=asiaColor, width=asiaLineW)
 
 if inAsia
     // update extremes
@@ -309,9 +315,9 @@ if inLondon and not inLondon[1]
     londonHigh := high
     londonLow  := low
     if showLondonBox
-        londonBox := box.new(londonT0, londonHigh, londonT0, londonLow, xloc=xloc.bar_time, bgcolor=color.new(color.blue, 85), border_color=color.blue)
-    londonHiLn := line.new(londonT0, londonHigh, time, londonHigh, xloc=xloc.bar_time, extend=extend.none, color=color.blue, width=1)
-    londonLoLn := line.new(londonT0, londonLow,  time, londonLow,  xloc=xloc.bar_time, extend=extend.none, color=color.blue, width=1)
+        londonBox := box.new(londonT0, londonHigh, londonT0, londonLow, xloc=xloc.bar_time, bgcolor=color.new(londonColor, londonFillT), border_color=londonColor)
+    londonHiLn := line.new(londonT0, londonHigh, time, londonHigh, xloc=xloc.bar_time, extend=extend.none, color=londonColor, width=londonLineW)
+    londonLoLn := line.new(londonT0, londonLow,  time, londonLow,  xloc=xloc.bar_time, extend=extend.none, color=londonColor, width=londonLineW)
 
 if inLondon
     londonHigh := math.max(londonHigh, high)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -251,10 +251,16 @@ asiaLoPlot  = plot(asiaLow,   color=color.new(color.teal,  0), title="Asia Low")
 londonHiPlot= plot(londonHigh,color=color.new(color.blue,  0), title="London High")
 londonLoPlot= plot(londonLow, color=color.new(color.blue,  0), title="London Low")
 
-// Daily open line at 18:00 ET
-bool doLine = showDailyOpenLine and (nyHour == 18 and nyMinute == 0)
-if doLine
-    line.new(bar_index, open, bar_index+1, open, xloc=xloc.bar_index, extend=extend.right, color=color.black, style=line.style_dotted, width=2)
+// Daily open line at 18:00 ET (robust via session time)
+var line dailyOpenLine = na
+bool tDailyOpenMinute = not na(time("", "1800-1801", TZ_NY))
+if showDailyOpenLine
+    // On the first bar of the 18:00–18:01 minute, create a new horizontal line at the bar open
+    if tDailyOpenMinute and not tDailyOpenMinute[1]
+        dailyOpenLine := line.new(time, open, time, open, xloc=xloc.bar_time, extend=extend.right, color=color.black, style=line.style_dotted, width=2)
+    // Keep the latest line extended to current bar time
+    if not na(dailyOpenLine)
+        line.set_x2(dailyOpenLine, time)
 
 // ==========================
 // Trigger: Reclaim AVWAP 9:30 (+ optional BOS)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -1,18 +1,6 @@
-//@version=5
-strategy(
-    title="NY Open AVWAP H1 Bias (MNQ)",
-    shorttitle="NY Open AVWAP H1 Bias",
-    overlay=true,
-    initial_capital=100000,
-    default_qty_type=strategy.fixed,
-    default_qty_value=1,
-    commission_type=strategy.commission.cash,
-    commission_value=1.5, // USD per contract (adjust to your broker)
-    slippage=2,           // slippage in ticks
-    pyramiding=0,
-    calc_on_order_fills=true,
-    calc_on_every_tick=true
-)
+//@version=6
+// Strategy declaration (single line to avoid parsing issues on some editors)
+strategy(title="NY Open AVWAP H1 Bias (MNQ)", shorttitle="NY Open AVWAP H1 Bias", overlay=true, initial_capital=100000, default_qty_type=strategy.fixed, default_qty_value=1, commission_type=strategy.commission.cash, commission_value=1.5, slippage=2, pyramiding=0, calc_on_order_fills=true, calc_on_every_tick=true)
 
 // ==========================
 // Inputs

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -1,0 +1,310 @@
+//@version=5
+strategy(
+    title="NY Open AVWAP H1 Bias (MNQ)",
+    shorttitle="NY Open AVWAP H1 Bias",
+    overlay=true,
+    initial_capital=100000,
+    default_qty_type=strategy.fixed,
+    default_qty_value=1,
+    commission_type=strategy.commission.cash,
+    commission_value=1.5, // USD per contract (adjust to your broker)
+    slippage=2,           // slippage in ticks
+    pyramiding=0,
+    calc_on_order_fills=true,
+    calc_on_every_tick=true
+)
+
+// ==========================
+// Inputs
+// ==========================
+// Trading window (ET)
+string TZ_NY = "America/New_York"
+inputSessionStartH = input.int(9, "Window start hour (ET)", minval=0, maxval=23)
+inputSessionStartM = input.int(30, "Window start minute (ET)", minval=0, maxval=59)
+inputSessionEndH   = input.int(9, "Window end hour (ET)", minval=0, maxval=23)
+inputSessionEndM   = input.int(50, "Window end minute (ET)", minval=0, maxval=59)
+
+// Anchors (ET)
+asiaH   = input.int(20, "Asia anchor hour (ET)", minval=0, maxval=23)
+asiaM   = input.int(0,  "Asia anchor minute (ET)", minval=0, maxval=59)
+londonH = input.int(3,  "London anchor hour (ET)", minval=0, maxval=23)
+londonM = input.int(0,  "London anchor minute (ET)", minval=0, maxval=59)
+preH    = input.int(8,  "8:00 anchor hour (ET)", minval=0, maxval=23)
+preM    = input.int(0,  "8:00 anchor minute (ET)", minval=0, maxval=59)
+openH   = input.int(9,  "9:30 anchor hour (ET)", minval=0, maxval=23)
+openM   = input.int(30, "9:30 anchor minute (ET)", minval=0, maxval=59)
+tenH    = input.int(10, "10:00 anchor hour (ET)", minval=0, maxval=23)
+tenM    = input.int(0,  "10:00 anchor minute (ET)", minval=0, maxval=59)
+
+// Bias mode
+modeStrict = input.bool(true, "Strict mode (all AVWAPs aligned; else Pragmatic mode)")
+minAligned = input.int(3, "Pragmatic: minimum AVWAPs aligned (out of Asia/London/8:00/9:30)", minval=1, maxval=4)
+requireBos = input.bool(false, "Require BOS (break of internal swing) with reclaim")
+
+// Risk management
+qtyContracts = input.int(1, "Contracts", minval=1)
+atrLen       = input.int(14, "ATR length", minval=1)
+atrMult      = input.float(0.3, "ATR buffer multiplier", step=0.05)
+minTicksBuf  = input.int(10, "Minimum buffer (ticks)", minval=0)
+rMultiple    = input.float(2.0, "Take profit multiple (R)", step=0.25)
+moveToBE     = input.bool(true, "Move stop to BE at 1R")
+timeStopMin  = input.int(15, "Time-stop minutes (exit if not hit TP/SL)", minval=1)
+
+// Visuals
+showLabels   = input.bool(true, "Show entry/exit labels")
+showDebug    = input.bool(false, "Show debug plots")
+
+// ==========================
+// Time helpers (ET)
+// ==========================
+nyHour   = hour(time, TZ_NY)
+nyMinute = minute(time, TZ_NY)
+nyDoy    = dayofyear(time, TZ_NY)
+nyIsNewDay = ta.change(nyDoy)
+
+inWindow = (
+     (nyHour > inputSessionStartH or (nyHour == inputSessionStartH and nyMinute >= inputSessionStartM)) and
+     (nyHour < inputSessionEndH   or (nyHour == inputSessionEndH   and nyMinute <= inputSessionEndM))
+)
+
+// ==========================
+// 9:00 H1 bias (live candle bias)
+// ==========================
+var float ny9Open = na
+isNY9OpenBar = (nyHour == 9 and nyMinute == 0)
+if isNY9OpenBar
+    ny9Open := open
+biasUp   = not na(ny9Open) and close > ny9Open
+biasDown = not na(ny9Open) and close < ny9Open
+
+// ==========================
+// Anchored VWAP builders (per-anchor state)
+// ==========================
+var float cumPV_asia   = na, cumV_asia   = na, avwap_asia   = na
+var float cumPV_london = na, cumV_london = na, avwap_london = na
+var float cumPV_pre    = na, cumV_pre    = na, avwap_pre    = na
+var float cumPV_open   = na, cumV_open   = na, avwap_open   = na
+var float cumPV_ten    = na, cumV_ten    = na, avwap_ten    = na
+
+source = hlc3
+pv     = source * volume
+
+isAsiaAnchor   = (nyHour == asiaH   and nyMinute == asiaM)
+isLondonAnchor = (nyHour == londonH and nyMinute == londonM)
+isPreAnchor    = (nyHour == preH    and nyMinute == preM)
+isOpenAnchor   = (nyHour == openH   and nyMinute == openM)
+isTenAnchor    = (nyHour == tenH    and nyMinute == tenM)
+
+// Update Asia AVWAP
+if isAsiaAnchor or na(cumPV_asia)
+    cumPV_asia := pv
+    cumV_asia  := volume
+else
+    cumPV_asia += pv
+    cumV_asia  += volume
+avwap_asia := cumPV_asia / cumV_asia
+
+// Update London AVWAP
+if isLondonAnchor or na(cumPV_london)
+    cumPV_london := pv
+    cumV_london  := volume
+else
+    cumPV_london += pv
+    cumV_london  += volume
+avwap_london := cumPV_london / cumV_london
+
+// Update 8:00 AVWAP
+if isPreAnchor or na(cumPV_pre)
+    cumPV_pre := pv
+    cumV_pre  := volume
+else
+    cumPV_pre += pv
+    cumV_pre  += volume
+avwap_pre := cumPV_pre / cumV_pre
+
+// Update 9:30 AVWAP
+if isOpenAnchor or na(cumPV_open)
+    cumPV_open := pv
+    cumV_open  := volume
+else
+    cumPV_open += pv
+    cumV_open  += volume
+avwap_open := cumPV_open / cumV_open
+
+// Update 10:00 AVWAP
+if isTenAnchor or na(cumPV_ten)
+    cumPV_ten := pv
+    cumV_ten  := volume
+else
+    cumPV_ten += pv
+    cumV_ten  += volume
+avwap_ten := cumPV_ten / cumV_ten
+
+// ==========================
+// Alignment logic (Strict vs Pragmatic)
+// ==========================
+// Only consider anchors available before/within the entry window (ignore 10:00 for 9:30-9:50 decisions)
+aboveAsia   = not na(avwap_asia)   and close > avwap_asia
+aboveLondon = not na(avwap_london) and close > avwap_london
+abovePre    = not na(avwap_pre)    and close > avwap_pre
+aboveOpen   = not na(avwap_open)   and close > avwap_open
+
+belowAsia   = not na(avwap_asia)   and close < avwap_asia
+belowLondon = not na(avwap_london) and close < avwap_london
+belowPre    = not na(avwap_pre)    and close < avwap_pre
+belowOpen   = not na(avwap_open)   and close < avwap_open
+
+strictLong  = biasUp   and aboveAsia   and aboveLondon and abovePre and aboveOpen
+strictShort = biasDown and belowAsia   and belowLondon and belowPre and belowOpen
+
+alignedCountLong  = (aboveAsia?1:0) + (aboveLondon?1:0) + (abovePre?1:0) + (aboveOpen?1:0)
+alignedCountShort = (belowAsia?1:0) + (belowLondon?1:0) + (belowPre?1:0) + (belowOpen?1:0)
+
+pragLong  = biasUp   and aboveOpen   and alignedCountLong  >= minAligned
+pragShort = biasDown and belowOpen   and alignedCountShort >= minAligned
+
+passLong  = (modeStrict ? strictLong  : pragLong)
+passShort = (modeStrict ? strictShort : pragShort)
+
+// ==========================
+// Trigger: Reclaim AVWAP 9:30 (+ optional BOS)
+// ==========================
+reclaimLong  = ta.crossover(close, avwap_open)
+reclaimShort = ta.crossunder(close, avwap_open)
+
+// Swings (for BOS and stops)
+left  = 2
+right = 2
+ph = ta.pivothigh(high, left, right)
+pl = ta.pivotlow(low, left, right)
+
+var float lastSwingHigh = na
+var float lastSwingLow  = na
+if not na(ph)
+    lastSwingHigh := ph
+if not na(pl)
+    lastSwingLow := pl
+
+bosLong  = not na(lastSwingHigh) and close > lastSwingHigh
+bosShort = not na(lastSwingLow)  and close < lastSwingLow
+
+triggerLong  = reclaimLong  and (requireBos ? bosLong  : true)
+triggerShort = reclaimShort and (requireBos ? bosShort : true)
+
+// Distance control: avoid chasing too far from AVWAP 9:30 (optional)
+atr = ta.atr(atrLen)
+maxDistATR = input.float(1.0, "Max distance from 9:30 AVWAP (ATR units)", step=0.1)
+withinDistLong  = not na(avwap_open) and (close - avwap_open) <= maxDistATR * atr
+withinDistShort = not na(avwap_open) and (avwap_open - close) <= maxDistATR * atr
+
+// ==========================
+// Per-day trade limits (NY day)
+// ==========================
+var bool tradedLongToday  = false
+var bool tradedShortToday = false
+var int  lastNYDoy = na
+if na(lastNYDoy) or nyIsNewDay
+    tradedLongToday  := false
+    tradedShortToday := false
+    lastNYDoy := nyDoy
+
+canLong  = inWindow and passLong  and not tradedLongToday
+canShort = inWindow and passShort and not tradedShortToday
+
+// ==========================
+// Orders and risk management
+// ==========================
+// Buffers
+bufferTicks  = minTicksBuf * syminfo.mintick
+bufferATR    = atr * atrMult
+bufferPoints = math.max(bufferTicks, bufferATR)
+
+// State for BE and time-stop
+var float longStopAtEntry  = na
+var float longTPAtEntry    = na
+var float shortStopAtEntry = na
+var float shortTPAtEntry   = na
+var int   longEntryTime    = na
+var int   shortEntryTime   = na
+
+enterLongCond  = canLong  and triggerLong  and withinDistLong  and not na(lastSwingLow)
+enterShortCond = canShort and triggerShort and withinDistShort and not na(lastSwingHigh)
+
+if enterLongCond and strategy.position_size <= 0
+    // Compute stop/TP from swing + buffer
+    longStop  = lastSwingLow - bufferPoints
+    // Approximate entry at close
+    longEntry = close
+    rDist     = math.max(longEntry - longStop, syminfo.mintick)
+    longTP    = longEntry + rMultiple * rDist
+
+    strategy.entry(id="L", direction=strategy.long, qty=qtyContracts)
+    strategy.exit(id="L-EXIT", from_entry="L", stop=longStop, limit=longTP)
+
+    tradedLongToday := true
+    longStopAtEntry := longStop
+    longTPAtEntry   := longTP
+    longEntryTime   := time
+
+if enterShortCond and strategy.position_size >= 0
+    shortStop  = lastSwingHigh + bufferPoints
+    shortEntry = close
+    rDist      = math.max(shortStop - shortEntry, syminfo.mintick)
+    shortTP    = shortEntry - rMultiple * rDist
+
+    strategy.entry(id="S", direction=strategy.short, qty=qtyContracts)
+    strategy.exit(id="S-EXIT", from_entry="S", stop=shortStop, limit=shortTP)
+
+    tradedShortToday := true
+    shortStopAtEntry := shortStop
+    shortTPAtEntry   := shortTP
+    shortEntryTime   := time
+
+// Move to BE at 1R
+if moveToBE and strategy.position_size > 0 and not na(longStopAtEntry)
+    entry = strategy.position_avg_price
+    rDist = entry - longStopAtEntry
+    if rDist > 0 and close - entry >= rDist
+        strategy.exit(id="L-EXIT", from_entry="L", stop=entry, limit=longTPAtEntry)
+
+if moveToBE and strategy.position_size < 0 and not na(shortStopAtEntry)
+    entry = strategy.position_avg_price
+    rDist = shortStopAtEntry - entry
+    if rDist > 0 and entry - close >= rDist
+        strategy.exit(id="S-EXIT", from_entry="S", stop=entry, limit=shortTPAtEntry)
+
+// Time-stop (minutes)
+if strategy.position_size > 0 and not na(longEntryTime)
+    minsInTrade = (time - longEntryTime) / 60000.0
+    if minsInTrade >= timeStopMin
+        strategy.close(id="L")
+        longEntryTime := na
+
+if strategy.position_size < 0 and not na(shortEntryTime)
+    minsInTrade = (time - shortEntryTime) / 60000.0
+    if minsInTrade >= timeStopMin
+        strategy.close(id="S")
+        shortEntryTime := na
+
+// Reset state on flat
+if strategy.position_size == 0
+    longStopAtEntry  := na
+    longTPAtEntry    := na
+    shortStopAtEntry := na
+    shortTPAtEntry   := na
+
+// ==========================
+// Plots & Debug
+// ==========================
+plot(avwap_asia,   color=color.new(color.teal,  0), title="AVWAP Asia")
+plot(avwap_london, color=color.new(color.blue,  0), title="AVWAP London")
+plot(avwap_pre,    color=color.new(color.gray,  0), title="AVWAP 8:00")
+plot(avwap_open,   color=color.new(color.orange,0), title="AVWAP 9:30")
+plot(avwap_ten,    color=color.new(color.purple,0), title="AVWAP 10:00")
+
+plotshape(showLabels and enterLongCond,  title="Long Signal",  style=shape.triangleup,   color=color.new(color.lime, 0), location=location.belowbar, size=size.tiny, text="L")
+plotshape(showLabels and enterShortCond, title="Short Signal", style=shape.triangledown, color=color.new(color.red,  0), location=location.abovebar, size=size.tiny, text="S")
+
+// Debug info
+if showDebug
+    label.new(bar_index, high, text=str.tostring(alignedCountLong) + "/" + str.tostring(alignedCountShort) + " aligned\n" + (passLong?"passLong":"") + (passShort?" passShort":""), style=label.style_label_down, color=color.new(color.silver, 60))

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -213,24 +213,34 @@ passLong  = (modeStrict ? strictLong  : pragLong)
 passShort = (modeStrict ? strictShort : pragShort)
 
 // ==========================
-// Previous Day High/Low as right-extended lines until daily close (like sessions)
+// Previous Day High/Low as dotted horizontal lines (green/blue), extend until daily close
 // ==========================
 var line pdhLine = na
 var line pdlLine = na
+var bool pdLinesActive = false
 prevDayHigh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
 prevDayLow  = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
 
-// Create PDH/PDL at start of new NY day
-if showPDLines and newDay
-    pdhLine := line.new(time, prevDayHigh, time, prevDayHigh, xloc=xloc.bar_time, extend=extend.right, color=pdHighColor, width=pdLineWidth)
-    pdlLine := line.new(time, prevDayLow,  time, prevDayLow,  xloc=xloc.bar_time, extend=extend.right, color=pdLowColor,  width=pdLineWidth)
+// Create PDH/PDL at the daily open minute (align with Daily Open handling)
+if showPDLines and isDailyOpenMinute and not isDailyOpenMinute[1]
+    pdhLine := line.new(time, prevDayHigh, time, prevDayHigh, xloc=xloc.bar_time, extend=extend.none, color=color.green, style=line.style_dotted, width=2)
+    pdlLine := line.new(time, prevDayLow,  time, prevDayLow,  xloc=xloc.bar_time, extend=extend.none, color=color.blue,  style=line.style_dotted, width=2)
+    pdLinesActive := true
 
-// Stop extending at daily close minute
-if showPDLines and isDailyCloseMinute and not isDailyCloseMinute[1]
+// Extend lines during the day
+if showPDLines and pdLinesActive
     if not na(pdhLine)
         line.set_x2(pdhLine, time)
     if not na(pdlLine)
         line.set_x2(pdlLine, time)
+
+// Stop extending at daily close minute
+if showPDLines and isDailyCloseMinute and not isDailyCloseMinute[1] and pdLinesActive
+    if not na(pdhLine)
+        line.set_x2(pdhLine, time)
+    if not na(pdlLine)
+        line.set_x2(pdlLine, time)
+    pdLinesActive := false
 
 // ==========================
 // Weekly High/Low (previous and current for context)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -268,81 +268,47 @@ if barstate.isfirst or newDay
 londonHigh := inLondon and (na(londonHigh) or high > londonHigh) ? high : londonHigh
 londonLow  := inLondon and (na(londonLow)  or low  < londonLow)  ? low  : londonLow
 
-// Draw Asia (20:00–00:00) and London (02:00–07:00) as boxes with H/L lines extended right
-var box  asiaBox   = na
-var line asiaHiLn  = na
-var line asiaLoLn  = na
-var int  asiaT0    = na
+// Draw Asia (20:00–00:00) and London (02:00–07:00) using plot series so colors are editable in Style
+// Carry H/L to the right until new day; optional fill as session box
+var float asiaHighCarry   = na
+var float asiaLowCarry    = na
+var float londonHighCarry = na
+var float londonLowCarry  = na
 
-var box  londonBox = na
-var line londonHiLn= na
-var line londonLoLn= na
-var int  londonT0  = na
+// Reset session carries on new day
+if newDay
+    asiaHighCarry   := na
+    asiaLowCarry    := na
+    londonHighCarry := na
+    londonLowCarry  := na
 
-// Asia session box and lines
-if inAsia and not inAsia[1]
-    // session start
-    asiaT0 := time
-    // reset extremes at session start
-    asiaHigh := high
-    asiaLow  := low
-    if showAsiaBox
-        asiaBox := box.new(asiaT0, asiaHigh, asiaT0, asiaLow, xloc=xloc.bar_time, bgcolor=color.new(asiaColor, asiaFillT), border_color=asiaColor)
-    // create lines anchored at session start
-    asiaHiLn := line.new(asiaT0, asiaHigh, time, asiaHigh, xloc=xloc.bar_time, extend=extend.none, color=asiaColor, width=asiaLineW)
-    asiaLoLn := line.new(asiaT0, asiaLow,  time, asiaLow,  xloc=xloc.bar_time, extend=extend.none, color=asiaColor, width=asiaLineW)
+// Asia updates
+if inAsia and na(asiaHighCarry)
+    asiaHighCarry := high
+    asiaLowCarry  := low
+if inAsia and not na(asiaHighCarry)
+    asiaHighCarry := math.max(asiaHighCarry, high)
+    asiaLowCarry  := math.min(asiaLowCarry,  low)
 
-if inAsia
-    // update extremes
-    asiaHigh := math.max(asiaHigh, high)
-    asiaLow  := math.min(asiaLow,  low)
-    // update box bounds
-    if not na(asiaBox)
-        box.set_right(asiaBox, time)
-        box.set_top(asiaBox,   asiaHigh)
-        box.set_bottom(asiaBox,asiaLow)
-    // update lines (left at start, right at now)
-    if not na(asiaHiLn)
-        line.set_xy1(asiaHiLn, asiaT0, asiaHigh)
-        line.set_xy2(asiaHiLn, time,   asiaHigh)
-    if not na(asiaLoLn)
-        line.set_xy1(asiaLoLn, asiaT0, asiaLow)
-        line.set_xy2(asiaLoLn, time,   asiaLow)
+// London updates
+if inLondon and na(londonHighCarry)
+    londonHighCarry := high
+    londonLowCarry  := low
+if inLondon and not na(londonHighCarry)
+    londonHighCarry := math.max(londonHighCarry, high)
+    londonLowCarry  := math.min(londonLowCarry,  low)
 
-// After session ends, keep extending lines to the right at fixed prices
-if not inAsia and not na(asiaHiLn)
-    line.set_x2(asiaHiLn, time)
-if not inAsia and not na(asiaLoLn)
-    line.set_x2(asiaLoLn, time)
+// Plot lines (editable in Style panel)
+asiaHiPlot   = plot(asiaHighCarry,   title="Asia High",   color=asiaColor,   linewidth=asiaLineW)
+asiaLoPlot   = plot(asiaLowCarry,    title="Asia Low",    color=asiaColor,   linewidth=asiaLineW)
+londonHiPlot = plot(londonHighCarry, title="London High", color=londonColor, linewidth=londonLineW)
+londonLoPlot = plot(londonLowCarry,  title="London Low",  color=londonColor, linewidth=londonLineW)
 
-// London session box and lines
-if inLondon and not inLondon[1]
-    londonT0 := time
-    londonHigh := high
-    londonLow  := low
-    if showLondonBox
-        londonBox := box.new(londonT0, londonHigh, londonT0, londonLow, xloc=xloc.bar_time, bgcolor=color.new(londonColor, londonFillT), border_color=londonColor)
-    londonHiLn := line.new(londonT0, londonHigh, time, londonHigh, xloc=xloc.bar_time, extend=extend.none, color=londonColor, width=londonLineW)
-    londonLoLn := line.new(londonT0, londonLow,  time, londonLow,  xloc=xloc.bar_time, extend=extend.none, color=londonColor, width=londonLineW)
-
-if inLondon
-    londonHigh := math.max(londonHigh, high)
-    londonLow  := math.min(londonLow,  low)
-    if not na(londonBox)
-        box.set_right(londonBox, time)
-        box.set_top(londonBox,   londonHigh)
-        box.set_bottom(londonBox,londonLow)
-    if not na(londonHiLn)
-        line.set_xy1(londonHiLn, londonT0, londonHigh)
-        line.set_xy2(londonHiLn, time,     londonHigh)
-    if not na(londonLoLn)
-        line.set_xy1(londonLoLn, londonT0, londonLow)
-        line.set_xy2(londonLoLn, time,     londonLow)
-
-if not inLondon and not na(londonHiLn)
-    line.set_x2(londonHiLn, time)
-if not inLondon and not na(londonLoLn)
-    line.set_x2(londonLoLn, time)
+// Optional fills for session boxes (color editable via Inputs; transparency via Inputs)
+asiaFillColor   = showAsiaBox   and not na(asiaHighCarry)   and not na(asiaLowCarry)   ? color.new(asiaColor,   asiaFillT)   : na
+londonFillColor = showLondonBox and not na(londonHighCarry) and not na(londonLowCarry) ? color.new(londonColor, londonFillT) : na
+fill(asiaHiPlot,   asiaLoPlot,   color=asiaFillColor,   title="Asia Box")
+fill(londonHiPlot, londonLoPlot, color=londonFillColor, title="London Box")
 
 // Daily open line (start at dailyOpenH:M, stop at dailyCloseH:M) + label
 var line dailyOpenLine = na

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -6,7 +6,7 @@ strategy(title="NY Open AVWAP H1 Bias (MNQ)", shorttitle="NY Open AVWAP H1 Bias"
 // Inputs
 // ==========================
 // Trading window (ET)
-const string TZ_NY = "America/New_York"
+string TZ_NY = "America/New_York"
 inputSessionStartH = input.int(9, "Window start hour (ET)", minval=0, maxval=23)
 inputSessionStartM = input.int(30, "Window start minute (ET)", minval=0, maxval=59)
 inputSessionEndH   = input.int(9, "Window end hour (ET)", minval=0, maxval=23)
@@ -66,11 +66,21 @@ biasDown = not na(ny9Open) and close < ny9Open
 // ==========================
 // Anchored VWAP builders (per-anchor state)
 // ==========================
-var float cumPV_asia   = na, cumV_asia   = na, avwap_asia   = na
-var float cumPV_london = na, cumV_london = na, avwap_london = na
-var float cumPV_pre    = na, cumV_pre    = na, avwap_pre    = na
-var float cumPV_open   = na, cumV_open   = na, avwap_open   = na
-var float cumPV_ten    = na, cumV_ten    = na, avwap_ten    = na
+var float cumPV_asia   = na
+var float cumV_asia    = na
+var float avwap_asia   = na
+var float cumPV_london = na
+var float cumV_london  = na
+var float avwap_london = na
+var float cumPV_pre    = na
+var float cumV_pre     = na
+var float avwap_pre    = na
+var float cumPV_open   = na
+var float cumV_open    = na
+var float avwap_open   = na
+var float cumPV_ten    = na
+var float cumV_ten     = na
+var float avwap_ten    = na
 
 source = hlc3
 pv     = source * volume

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -222,8 +222,8 @@ premHigh := inPrem and (na(premHigh) or high > premHigh) ? high : premHigh
 premLow  := inPrem and (na(premLow)  or low  < premLow)  ? low  : premLow
 premHiPlot = useManualPremHL and manualPremHigh != 0.0 ? manualPremHigh : premHigh
 premLoPlot = useManualPremHL and manualPremLow  != 0.0 ? manualPremLow  : premLow
-plot(premHiPlot, color=color.new(color.yellow, 0), title="Premarket High")
-plot(premLoPlot, color=color.new(color.yellow, 0), title="Premarket Low")
+plot(premHiPlot, color=color.new(color.orange, 0), title="Premarket High")
+plot(premLoPlot, color=color.new(color.orange, 0), title="Premarket Low")
 
 // Asia session hi/low and box
 inAsia = f_inSession(asiaStartH, asiaStartM, asiaEndH, asiaEndM)
@@ -246,15 +246,10 @@ londonHigh := inLondon and (na(londonHigh) or high > londonHigh) ? high : london
 londonLow  := inLondon and (na(londonLow)  or low  < londonLow)  ? low  : londonLow
 
 // Draw session boxes (using fill between highs/lows)
-asiaHiPlot  = plot(asiaHigh,  color=color.new(color.teal, 70), title="Asia High")
-asiaLoPlot  = plot(asiaLow,   color=color.new(color.teal, 70), title="Asia Low")
-londonHiPlot= plot(londonHigh,color=color.new(color.blue, 70), title="London High")
-londonLoPlot= plot(londonLow, color=color.new(color.blue, 70), title="London Low")
-premHiFill  = plot(premHiPlot,color=color.new(color.orange,70), title="Premarket High (box)")
-premLoFill  = plot(premLoPlot,color=color.new(color.orange,70), title="Premarket Low (box)")
-fill(asiaHiPlot,  asiaLoPlot,  color=color.new(color.teal,  85), title="Asia Box")
-fill(londonHiPlot,londonLoPlot,color=color.new(color.blue,  85), title="London Box")
-fill(premHiFill,  premLoFill,  color=color.new(color.orange,85), title="Premarket Box")
+asiaHiPlot  = plot(asiaHigh,  color=color.new(color.teal,  0), title="Asia High")
+asiaLoPlot  = plot(asiaLow,   color=color.new(color.teal,  0), title="Asia Low")
+londonHiPlot= plot(londonHigh,color=color.new(color.blue,  0), title="London High")
+londonLoPlot= plot(londonLow, color=color.new(color.blue,  0), title="London Low")
 
 // Daily open line at 18:00 ET
 bool doLine = showDailyOpenLine and (nyHour == 18 and nyMinute == 0)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -214,20 +214,40 @@ passShort = (modeStrict ? strictShort : pragShort)
 
 // ==========================
 // Previous Day High/Low as dotted horizontal lines (green/blue), extend until daily close
+// Session-based calculation aligned to custom day (dailyOpenH:M .. dailyCloseH:M)
 // ==========================
 var line pdhLine = na
 var line pdlLine = na
 var bool pdLinesActive = false
-prevDayHigh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
-prevDayLow  = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
+var float currDayHigh = na
+var float currDayLow  = na
+var float prevDayHighSess = na
+var float prevDayLowSess  = na
 
-// Create PDH/PDL at the daily open minute (align with Daily Open handling)
-if showPDLines and isDailyOpenMinute and not isDailyOpenMinute[1]
-    pdhLine := line.new(time, prevDayHigh, time, prevDayHigh, xloc=xloc.bar_time, extend=extend.none, color=color.green, style=line.style_dotted, width=2)
-    pdlLine := line.new(time, prevDayLow,  time, prevDayLow,  xloc=xloc.bar_time, extend=extend.none, color=color.blue,  style=line.style_dotted, width=2)
-    pdLinesActive := true
+// On first bar, initialize current day extremes
+if barstate.isfirst
+    currDayHigh := high
+    currDayLow  := low
 
-// Extend lines during the day
+// Update current day extremes continuously
+currDayHigh := na(currDayHigh) ? high : math.max(currDayHigh, high)
+currDayLow  := na(currDayLow)  ? low  : math.min(currDayLow,  low)
+
+// At the daily open minute, finalize previous day extremes and create PDH/PDL lines
+if isDailyOpenMinute and not isDailyOpenMinute[1]
+    // Previous day extremes are those accumulated up to this open
+    prevDayHighSess := currDayHigh
+    prevDayLowSess  := currDayLow
+    // Reset for new day
+    currDayHigh := high
+    currDayLow  := low
+    // Create lines if enabled and have valid prev values
+    if showPDLines and not na(prevDayHighSess) and not na(prevDayLowSess)
+        pdhLine := line.new(time, prevDayHighSess, time, prevDayHighSess, xloc=xloc.bar_time, extend=extend.none, color=color.green, style=line.style_dotted, width=2)
+        pdlLine := line.new(time, prevDayLowSess,  time, prevDayLowSess,  xloc=xloc.bar_time, extend=extend.none, color=color.blue,  style=line.style_dotted, width=2)
+        pdLinesActive := true
+
+// Extend PDH/PDL during the day
 if showPDLines and pdLinesActive
     if not na(pdhLine)
         line.set_x2(pdhLine, time)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -67,11 +67,16 @@ moveToBE     = input.bool(true, "Move stop to BE at 1R")
 timeStopMin  = input.int(15, "Time-stop minutes (exit if not hit TP/SL)", minval=1)
 
 // Visuals
-showLabels   = input.bool(true, "Show entry/exit labels")
-showDebug    = input.bool(false, "Show debug plots")
-showAsiaBox  = input.bool(true, "Show Asia box (pink)")
-showLondonBox= input.bool(true, "Show London box (blue)")
-showWeeklyHL = input.bool(true, "Show Weekly High/Low")
+showLabels    = input.bool(true, "Show entry/exit labels")
+showDebug     = input.bool(false, "Show debug plots")
+showAsiaBox   = input.bool(true, "Show Asia box (pink)")
+showLondonBox = input.bool(true, "Show London box (blue)")
+showWeeklyHL  = input.bool(true, "Show Weekly High/Low")
+// Previous Day H/L lines (like sessions)
+showPDLines   = input.bool(true, "Show Previous Day H/L lines")
+pdHighColor   = input.color(color.new(color.green, 0), "PD High Color")
+pdLowColor    = input.color(color.new(color.red, 0),    "PD Low Color")
+pdLineWidth   = input.int(1, "PD Line Width", minval=1, maxval=5)
 
 // ==========================
 // Time helpers (ET)
@@ -205,12 +210,24 @@ passLong  = (modeStrict ? strictLong  : pragLong)
 passShort = (modeStrict ? strictShort : pragShort)
 
 // ==========================
-// Previous Day High/Low (robust via 1D security)
+// Previous Day High/Low as right-extended lines until daily close (like sessions)
 // ==========================
-pdh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
-pdl = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
-plot(pdh, color=color.new(color.fuchsia, 0), title="PDH")
-plot(pdl, color=color.new(color.fuchsia, 0), title="PDL")
+var line pdhLine = na
+var line pdlLine = na
+prevDayHigh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
+prevDayLow  = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
+
+// Create PDH/PDL at start of new NY day
+if showPDLines and newDay
+    pdhLine := line.new(time, prevDayHigh, time, prevDayHigh, xloc=xloc.bar_time, extend=extend.right, color=pdHighColor, width=pdLineWidth)
+    pdlLine := line.new(time, prevDayLow,  time, prevDayLow,  xloc=xloc.bar_time, extend=extend.right, color=pdLowColor,  width=pdLineWidth)
+
+// Stop extending at daily close minute
+if showPDLines and isDailyCloseMinute and not isDailyCloseMinute[1]
+    if not na(pdhLine)
+        line.set_x2(pdhLine, time)
+    if not na(pdlLine)
+        line.set_x2(pdlLine, time)
 
 // ==========================
 // Weekly High/Low (previous and current for context)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -256,15 +256,81 @@ if barstate.isfirst or newDay
 londonHigh := inLondon and (na(londonHigh) or high > londonHigh) ? high : londonHigh
 londonLow  := inLondon and (na(londonLow)  or low  < londonLow)  ? low  : londonLow
 
-// Draw session lines and optional boxes
-asiaHiPlot  = plot(asiaHigh,  color=color.new(color.fuchsia, 0), title="Asia High")
-asiaLoPlot  = plot(asiaLow,   color=color.new(color.fuchsia, 0), title="Asia Low")
-londonHiPlot= plot(londonHigh,color=color.new(color.blue,    0), title="London High")
-londonLoPlot= plot(londonLow, color=color.new(color.blue,    0), title="London Low")
-asiaFillColor   = showAsiaBox   and not na(asiaHigh)   and not na(asiaLow)   ? color.new(color.fuchsia, 85) : na
-londonFillColor = showLondonBox and not na(londonHigh) and not na(londonLow) ? color.new(color.blue,    85) : na
-fill(asiaHiPlot,   asiaLoPlot,   color=asiaFillColor,   title="Asia Box")
-fill(londonHiPlot, londonLoPlot, color=londonFillColor, title="London Box")
+// Draw Asia (20:00–00:00) and London (02:00–07:00) as boxes with H/L lines extended right
+var box  asiaBox   = na
+var line asiaHiLn  = na
+var line asiaLoLn  = na
+var int  asiaT0    = na
+
+var box  londonBox = na
+var line londonHiLn= na
+var line londonLoLn= na
+var int  londonT0  = na
+
+// Asia session box and lines
+if inAsia and not inAsia[1]
+    // session start
+    asiaT0 := time
+    // reset extremes at session start
+    asiaHigh := high
+    asiaLow  := low
+    if showAsiaBox
+        asiaBox := box.new(asiaT0, asiaHigh, asiaT0, asiaLow, xloc=xloc.bar_time, bgcolor=color.new(color.fuchsia, 85), border_color=color.fuchsia)
+    // create lines anchored at session start
+    asiaHiLn := line.new(asiaT0, asiaHigh, time, asiaHigh, xloc=xloc.bar_time, extend=extend.none, color=color.fuchsia, width=1)
+    asiaLoLn := line.new(asiaT0, asiaLow,  time, asiaLow,  xloc=xloc.bar_time, extend=extend.none, color=color.fuchsia, width=1)
+
+if inAsia
+    // update extremes
+    asiaHigh := math.max(asiaHigh, high)
+    asiaLow  := math.min(asiaLow,  low)
+    // update box bounds
+    if not na(asiaBox)
+        box.set_right(asiaBox, time)
+        box.set_top(asiaBox,   asiaHigh)
+        box.set_bottom(asiaBox,asiaLow)
+    // update lines (left at start, right at now)
+    if not na(asiaHiLn)
+        line.set_xy1(asiaHiLn, asiaT0, asiaHigh)
+        line.set_xy2(asiaHiLn, time,   asiaHigh)
+    if not na(asiaLoLn)
+        line.set_xy1(asiaLoLn, asiaT0, asiaLow)
+        line.set_xy2(asiaLoLn, time,   asiaLow)
+
+// After session ends, keep extending lines to the right at fixed prices
+if not inAsia and not na(asiaHiLn)
+    line.set_x2(asiaHiLn, time)
+if not inAsia and not na(asiaLoLn)
+    line.set_x2(asiaLoLn, time)
+
+// London session box and lines
+if inLondon and not inLondon[1]
+    londonT0 := time
+    londonHigh := high
+    londonLow  := low
+    if showLondonBox
+        londonBox := box.new(londonT0, londonHigh, londonT0, londonLow, xloc=xloc.bar_time, bgcolor=color.new(color.blue, 85), border_color=color.blue)
+    londonHiLn := line.new(londonT0, londonHigh, time, londonHigh, xloc=xloc.bar_time, extend=extend.none, color=color.blue, width=1)
+    londonLoLn := line.new(londonT0, londonLow,  time, londonLow,  xloc=xloc.bar_time, extend=extend.none, color=color.blue, width=1)
+
+if inLondon
+    londonHigh := math.max(londonHigh, high)
+    londonLow  := math.min(londonLow,  low)
+    if not na(londonBox)
+        box.set_right(londonBox, time)
+        box.set_top(londonBox,   londonHigh)
+        box.set_bottom(londonBox,londonLow)
+    if not na(londonHiLn)
+        line.set_xy1(londonHiLn, londonT0, londonHigh)
+        line.set_xy2(londonHiLn, time,     londonHigh)
+    if not na(londonLoLn)
+        line.set_xy1(londonLoLn, londonT0, londonLow)
+        line.set_xy2(londonLoLn, time,     londonLow)
+
+if not inLondon and not na(londonHiLn)
+    line.set_x2(londonHiLn, time)
+if not inLondon and not na(londonLoLn)
+    line.set_x2(londonLoLn, time)
 
 // Daily open line (start at dailyOpenH:M, stop at dailyCloseH:M) + label
 var line dailyOpenLine = na

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -218,6 +218,8 @@ passShort = (modeStrict ? strictShort : pragShort)
 // ==========================
 var line pdhLine = na
 var line pdlLine = na
+var label pdhLabel = na
+var label pdlLabel = na
 var bool pdLinesActive = false
 var float currDayHigh = na
 var float currDayLow  = na
@@ -245,14 +247,22 @@ if isDailyOpenMinute and not isDailyOpenMinute[1]
     if showPDLines and not na(prevDayHighSess) and not na(prevDayLowSess)
         pdhLine := line.new(time, prevDayHighSess, time, prevDayHighSess, xloc=xloc.bar_time, extend=extend.none, color=color.green, style=line.style_dotted, width=2)
         pdlLine := line.new(time, prevDayLowSess,  time, prevDayLowSess,  xloc=xloc.bar_time, extend=extend.none, color=color.blue,  style=line.style_dotted, width=2)
+        pdhLabel := label.new(time, prevDayHighSess, "PDH", xloc=xloc.bar_time, style=label.style_label_left, color=color.new(color.white, 100), textcolor=color.green, size=size.tiny)
+        pdlLabel := label.new(time, prevDayLowSess,  "PDL", xloc=xloc.bar_time, style=label.style_label_left, color=color.new(color.white, 100), textcolor=color.blue,  size=size.tiny)
         pdLinesActive := true
 
 // Extend PDH/PDL during the day
 if showPDLines and pdLinesActive
     if not na(pdhLine)
         line.set_x2(pdhLine, time)
+        if not na(pdhLabel)
+            label.set_x(pdhLabel, time)
+            label.set_y(pdhLabel, line.get_y1(pdhLine))
     if not na(pdlLine)
         line.set_x2(pdlLine, time)
+        if not na(pdlLabel)
+            label.set_x(pdlLabel, time)
+            label.set_y(pdlLabel, line.get_y1(pdlLine))
 
 // Stop extending at daily close minute
 if showPDLines and isDailyCloseMinute and not isDailyCloseMinute[1] and pdLinesActive

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -45,8 +45,12 @@ useManualPremHL   = input.bool(false, "Use manual Premarket High/Low")
 manualPremHigh    = input.float(0.0, "Premarket High (manual)")
 manualPremLow     = input.float(0.0, "Premarket Low (manual)")
 
-// Daily open line toggle
-showDailyOpenLine = input.bool(true, "Show Daily Open line (18:00 ET)")
+// Daily open line toggle and timing
+showDailyOpenLine = input.bool(true, "Show Daily Open line")
+dailyOpenH = input.int(18, "Daily open hour (ET)", minval=0, maxval=23)
+dailyOpenM = input.int(0,  "Daily open minute (ET)", minval=0, maxval=59)
+dailyCloseH = input.int(17, "Daily close hour (ET)", minval=0, maxval=23)
+dailyCloseM = input.int(0,  "Daily close minute (ET)", minval=0, maxval=59)
 
 // Bias mode
 modeStrict = input.bool(true, "Strict mode (all AVWAPs aligned; else Pragmatic mode)")
@@ -251,16 +255,24 @@ asiaLoPlot  = plot(asiaLow,   color=color.new(color.teal,  0), title="Asia Low")
 londonHiPlot= plot(londonHigh,color=color.new(color.blue,  0), title="London High")
 londonLoPlot= plot(londonLow, color=color.new(color.blue,  0), title="London Low")
 
-// Daily open line at 18:00 ET (robust via session time)
+// Daily open line (start at dailyOpenH:M, stop at dailyCloseH:M)
 var line dailyOpenLine = na
-bool tDailyOpenMinute = not na(time("", "1800-1801", TZ_NY))
+var bool dailyOpenActive = false
+isDailyOpenMinute  = (nyHour == dailyOpenH and nyMinute == dailyOpenM)
+isDailyCloseMinute = (nyHour == dailyCloseH and nyMinute == dailyCloseM)
+
 if showDailyOpenLine
-    // On the first bar of the 18:00–18:01 minute, create a new horizontal line at the bar open
-    if tDailyOpenMinute and not tDailyOpenMinute[1]
-        dailyOpenLine := line.new(time, open, time, open, xloc=xloc.bar_time, extend=extend.right, color=color.black, style=line.style_dotted, width=2)
-    // Keep the latest line extended to current bar time
-    if not na(dailyOpenLine)
+    // Start new line at open minute
+    if isDailyOpenMinute and not isDailyOpenMinute[1]
+        dailyOpenLine := line.new(time, open, time, open, xloc=xloc.bar_time, extend=extend.none, color=color.black, style=line.style_dotted, width=2)
+        dailyOpenActive := true
+    // Extend line until close minute
+    if dailyOpenActive and not na(dailyOpenLine)
         line.set_x2(dailyOpenLine, time)
+    // Stop extending at close minute
+    if isDailyCloseMinute and not isDailyCloseMinute[1] and dailyOpenActive and not na(dailyOpenLine)
+        line.set_x2(dailyOpenLine, time)
+        dailyOpenActive := false
 
 // ==========================
 // Trigger: Reclaim AVWAP 9:30 (+ optional BOS)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -1,6 +1,6 @@
 //@version=6
-// Strategy declaration (single line to avoid parsing issues on some editors)
-strategy(title="NY Open AVWAP H1 Bias (MNQ)", shorttitle="NY Open AVWAP H1 Bias", overlay=true, initial_capital=100000, default_qty_type=strategy.fixed, default_qty_value=1, commission_type=strategy.commission.cash, commission_value=1.5, slippage=2, pyramiding=0, calc_on_order_fills=true, calc_on_every_tick=true)
+// Strategy declaration (kept minimal for compatibility across editors)
+strategy("NY Open AVWAP H1 Bias (MNQ)", overlay=true, initial_capital=100000, pyramiding=0, calc_on_order_fills=true, calc_on_every_tick=true)
 
 // ==========================
 // Inputs
@@ -199,7 +199,8 @@ withinDistShort = not na(avwap_open) and (avwap_open - close) <= maxDistATR * at
 var bool tradedLongToday  = false
 var bool tradedShortToday = false
 var int  lastNYDom = na
-if na(lastNYDom) or nyIsNewDay
+isNewSessionBar = ta.change(time("D", TZ_NY))
+if na(lastNYDom) or isNewSessionBar
     tradedLongToday  := false
     tradedShortToday := false
     lastNYDom := nyDayOfMon

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -211,12 +211,17 @@ passLong  = (modeStrict ? strictLong  : pragLong)
 passShort = (modeStrict ? strictShort : pragShort)
 
 // ==========================
-// Previous Day High/Low (robust via 1D security)
+// Previous Day High/Low (as right-extended lines per day)
 // ==========================
-pdh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
-pdl = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
-plot(pdh, color=color.new(color.fuchsia, 0), title="PDH")
-plot(pdl, color=color.new(color.fuchsia, 0), title="PDL")
+var line pdhLine = na
+var line pdlLine = na
+prevDayHigh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
+prevDayLow  = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
+
+if newDay
+    // create new PDH/PDL lines at start of new day
+    pdhLine := line.new(time, prevDayHigh, time, prevDayHigh, xloc=xloc.bar_time, extend=extend.right, color=color.new(color.fuchsia, 0), style=line.style_solid, width=1)
+    pdlLine := line.new(time, prevDayLow,  time, prevDayLow,  xloc=xloc.bar_time, extend=extend.right, color=color.new(color.fuchsia, 0), style=line.style_solid, width=1)
 
 // ==========================
 // Weekly High/Low (previous and current for context)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -99,6 +99,9 @@ f_inSession(sh, sm, eh, em) =>
 
 // Daily change flag (compute once per bar)
 newDay = ta.change(time("D", TZ_NY)) != 0
+// Precompute daily open/close minute flags for reuse
+isDailyOpenMinute  = (nyHour == dailyOpenH and nyMinute == dailyOpenM)
+isDailyCloseMinute = (nyHour == dailyCloseH and nyMinute == dailyCloseM)
 
 // ==========================
 // 9:00 H1 bias (live candle bias)
@@ -381,8 +384,6 @@ if not inLondon and not na(londonLoLn)
 var line dailyOpenLine = na
 var label dailyOpenLabel = na
 var bool dailyOpenActive = false
-isDailyOpenMinute  = (nyHour == dailyOpenH and nyMinute == dailyOpenM)
-isDailyCloseMinute = (nyHour == dailyCloseH and nyMinute == dailyCloseM)
 
 if showDailyOpenLine
     // Start new line at open minute

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -199,8 +199,17 @@ withinDistShort = not na(avwap_open) and (avwap_open - close) <= maxDistATR * at
 var bool tradedLongToday  = false
 var bool tradedShortToday = false
 var int  lastNYDom = na
-isNewSessionBar = ta.change(time("D", TZ_NY))
-if na(lastNYDom) or isNewSessionBar
+// Detect new NY day using daily time change; cast to bool
+bool isNewSessionBar = ta.change(time("D", TZ_NY)) != 0
+
+// Initialize on first bar
+if barstate.isfirst
+    tradedLongToday  := false
+    tradedShortToday := false
+    lastNYDom := nyDayOfMon
+
+// Reset flags on new session bar
+if isNewSessionBar
     tradedLongToday  := false
     tradedShortToday := false
     lastNYDom := nyDayOfMon

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -223,16 +223,16 @@ passShort = (modeStrict ? strictShort : pragShort)
 // ==========================
 prevDayHigh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
 prevDayLow  = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
-plot(showPDLevels ? prevDayHigh : na, color=pdHighColor, title="PDH", linewidth=pdLineWidth)
-plot(showPDLevels ? prevDayLow  : na, color=pdLowColor,  title="PDL", linewidth=pdLineWidth)
+plot(showPDLevels ? prevDayHigh : na, title="PDH")
+plot(showPDLevels ? prevDayLow  : na, title="PDL")
 
 // ==========================
 // Weekly High/Low (previous and current for context)
 // ==========================
 pwh = request.security(syminfo.tickerid, "1W", high[1],lookahead=barmerge.lookahead_off)
 pwl = request.security(syminfo.tickerid, "1W", low[1], lookahead=barmerge.lookahead_off)
-plot(showWeeklyHL ? pwh : na, color=weeklyHighColor, title="Prev Weekly High", linewidth=weeklyLineWidth)
-plot(showWeeklyHL ? pwl : na, color=weeklyLowColor,  title="Prev Weekly Low",  linewidth=weeklyLineWidth)
+plot(showWeeklyHL ? pwh : na, title="Prev Weekly High")
+plot(showWeeklyHL ? pwl : na, title="Prev Weekly Low")
 
 // Premarket (18:00–9:30 ET by default)
 inPrem = f_inSession(premStartH, premStartM, premEndH, premEndM)
@@ -245,8 +245,8 @@ premHigh := inPrem and (na(premHigh) or high > premHigh) ? high : premHigh
 premLow  := inPrem and (na(premLow)  or low  < premLow)  ? low  : premLow
 premHiPlot = useManualPremHL and manualPremHigh != 0.0 ? manualPremHigh : premHigh
 premLoPlot = useManualPremHL and manualPremLow  != 0.0 ? manualPremLow  : premLow
-plot(premHiPlot, color=color.new(color.orange, 0), title="Premarket High")
-plot(premLoPlot, color=color.new(color.orange, 0), title="Premarket Low")
+plot(premHiPlot, title="Premarket High")
+plot(premLoPlot, title="Premarket Low")
 
 // Asia session hi/low and box
 inAsia = f_inSession(asiaStartH, asiaStartM, asiaEndH, asiaEndM)
@@ -299,10 +299,10 @@ if inLondon and not na(londonHighCarry)
     londonLowCarry  := math.min(londonLowCarry,  low)
 
 // Plot lines (editable in Style panel)
-asiaHiPlot   = plot(asiaHighCarry,   title="Asia High",   color=asiaColor,   linewidth=asiaLineW)
-asiaLoPlot   = plot(asiaLowCarry,    title="Asia Low",    color=asiaColor,   linewidth=asiaLineW)
-londonHiPlot = plot(londonHighCarry, title="London High", color=londonColor, linewidth=londonLineW)
-londonLoPlot = plot(londonLowCarry,  title="London Low",  color=londonColor, linewidth=londonLineW)
+asiaHiPlot   = plot(asiaHighCarry,   title="Asia High")
+asiaLoPlot   = plot(asiaLowCarry,    title="Asia Low")
+londonHiPlot = plot(londonHighCarry, title="London High")
+londonLoPlot = plot(londonLowCarry,  title="London Low")
 
 // Optional fills for session boxes (color editable via Inputs; transparency via Inputs)
 asiaFillColor   = showAsiaBox   and not na(asiaHighCarry)   and not na(asiaLowCarry)   ? color.new(asiaColor,   asiaFillT)   : na

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -257,10 +257,7 @@ fill(londonHiPlot,londonLoPlot,color=color.new(color.blue,  85), title="London B
 fill(premHiFill,  premLoFill,  color=color.new(color.orange,85), title="Premarket Box")
 
 // Daily open line at 18:00 ET
-if showDailyOpenLine and (nyHour == 18 and nyMinute == 0)
-    doLine = true
-else
-    doLine = false
+bool doLine = showDailyOpenLine and (nyHour == 18 and nyMinute == 0)
 if doLine
     line.new(bar_index, open, bar_index+1, open, xloc=xloc.bar_index, extend=extend.right, color=color.black, style=line.style_dotted, width=2)
 

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -202,18 +202,12 @@ passLong  = (modeStrict ? strictLong  : pragLong)
 passShort = (modeStrict ? strictShort : pragShort)
 
 // ==========================
-// Previous Day High/Low and Session High/Low + Boxes
+// Previous Day High/Low (robust via 1D security)
 // ==========================
-// Previous day (RTH day aligned with TZ_NY daily)
-var float pdHigh = na
-var float pdLow  = na
-var int   curDay = nyDayOfMon
-if newDay
-    pdHigh := high[1]
-    pdLow  := low[1]
-// Plot PDH/PDL
-plot(pdHigh, color=color.new(color.fuchsia, 0), title="PDH")
-plot(pdLow,  color=color.new(color.fuchsia, 0), title="PDL")
+pdh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
+pdl = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
+plot(pdh, color=color.new(color.fuchsia, 0), title="PDH")
+plot(pdl, color=color.new(color.fuchsia, 0), title="PDL")
 
 // Premarket (18:00–9:30 ET by default)
 inPrem = f_inSession(premStartH, premStartM, premEndH, premEndM)
@@ -255,8 +249,9 @@ asiaLoPlot  = plot(asiaLow,   color=color.new(color.teal,  0), title="Asia Low")
 londonHiPlot= plot(londonHigh,color=color.new(color.blue,  0), title="London High")
 londonLoPlot= plot(londonLow, color=color.new(color.blue,  0), title="London Low")
 
-// Daily open line (start at dailyOpenH:M, stop at dailyCloseH:M)
+// Daily open line (start at dailyOpenH:M, stop at dailyCloseH:M) + label
 var line dailyOpenLine = na
+var label dailyOpenLabel = na
 var bool dailyOpenActive = false
 isDailyOpenMinute  = (nyHour == dailyOpenH and nyMinute == dailyOpenM)
 isDailyCloseMinute = (nyHour == dailyCloseH and nyMinute == dailyCloseM)
@@ -265,10 +260,14 @@ if showDailyOpenLine
     // Start new line at open minute
     if isDailyOpenMinute and not isDailyOpenMinute[1]
         dailyOpenLine := line.new(time, open, time, open, xloc=xloc.bar_time, extend=extend.none, color=color.black, style=line.style_dotted, width=2)
+        dailyOpenLabel := label.new(time, open, "Daily Open", xloc=xloc.bar_time, style=label.style_label_left, color=color.new(color.white, 100), textcolor=color.black, size=size.tiny)
         dailyOpenActive := true
-    // Extend line until close minute
+    // Extend line and keep label aligned until close minute
     if dailyOpenActive and not na(dailyOpenLine)
         line.set_x2(dailyOpenLine, time)
+        if not na(dailyOpenLabel)
+            label.set_x(dailyOpenLabel, time)
+            label.set_y(dailyOpenLabel, line.get_y1(dailyOpenLine))
     // Stop extending at close minute
     if isDailyCloseMinute and not isDailyCloseMinute[1] and dailyOpenActive and not na(dailyOpenLine)
         line.set_x2(dailyOpenLine, time)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -78,6 +78,14 @@ asiaLineW    = input.int(1, "Asia line width", minval=1, maxval=5)
 londonColor  = input.color(color.blue, "London color")
 londonFillT  = input.int(85, "London box transparency", minval=0, maxval=100)
 londonLineW  = input.int(1, "London line width", minval=1, maxval=5)
+// Level style customization
+showPDLevels = input.bool(true, "Show Previous Day H/L")
+pdHighColor  = input.color(color.new(color.green, 0), "PD High Color")
+pdLowColor   = input.color(color.new(color.red,   0), "PD Low Color")
+pdLineWidth  = input.int(1, "PD Line Width", minval=1, maxval=5)
+weeklyHighColor = input.color(color.new(color.green, 0), "Weekly High Color")
+weeklyLowColor  = input.color(color.new(color.blue,  0), "Weekly Low Color")
+weeklyLineWidth = input.int(1, "Weekly Line Width", minval=1, maxval=5)
 
 // ==========================
 // Time helpers (ET)
@@ -211,27 +219,20 @@ passLong  = (modeStrict ? strictLong  : pragLong)
 passShort = (modeStrict ? strictShort : pragShort)
 
 // ==========================
-// Previous Day High/Low (as right-extended lines per day)
+// Previous Day High/Low (configurable color/width) via 1D security
 // ==========================
-var line pdhLine = na
-var line pdlLine = na
 prevDayHigh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
 prevDayLow  = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
-
-if newDay
-    // create new PDH/PDL lines at start of new day
-    pdhLine := line.new(time, prevDayHigh, time, prevDayHigh, xloc=xloc.bar_time, extend=extend.right, color=color.new(color.fuchsia, 0), style=line.style_solid, width=1)
-    pdlLine := line.new(time, prevDayLow,  time, prevDayLow,  xloc=xloc.bar_time, extend=extend.right, color=color.new(color.fuchsia, 0), style=line.style_solid, width=1)
+plot(showPDLevels ? prevDayHigh : na, color=pdHighColor, title="PDH", linewidth=pdLineWidth)
+plot(showPDLevels ? prevDayLow  : na, color=pdLowColor,  title="PDL", linewidth=pdLineWidth)
 
 // ==========================
 // Weekly High/Low (previous and current for context)
 // ==========================
-wh  = request.security(syminfo.tickerid, "1W", high,   lookahead=barmerge.lookahead_off)
-wl  = request.security(syminfo.tickerid, "1W", low,    lookahead=barmerge.lookahead_off)
 pwh = request.security(syminfo.tickerid, "1W", high[1],lookahead=barmerge.lookahead_off)
 pwl = request.security(syminfo.tickerid, "1W", low[1], lookahead=barmerge.lookahead_off)
-plot(showWeeklyHL ? pwh : na, color=color.new(color.green, 0), title="Prev Weekly High")
-plot(showWeeklyHL ? pwl : na, color=color.new(color.blue,  0), title="Prev Weekly Low")
+plot(showWeeklyHL ? pwh : na, color=weeklyHighColor, title="Prev Weekly High", linewidth=weeklyLineWidth)
+plot(showWeeklyHL ? pwl : na, color=weeklyLowColor,  title="Prev Weekly Low",  linewidth=weeklyLineWidth)
 
 // Premarket (18:00–9:30 ET by default)
 inPrem = f_inSession(premStartH, premStartM, premEndH, premEndM)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -78,10 +78,12 @@ nyIsNewDay  = ta.change(nyDayOfMon)
 inWindow = (nyHour > inputSessionStartH or (nyHour == inputSessionStartH and nyMinute >= inputSessionStartM)) and (nyHour < inputSessionEndH or (nyHour == inputSessionEndH and nyMinute <= inputSessionEndM))
 
 // Helper: session membership handling midnight-crossing sessions
-f_inSession(int sh, int sm, int eh, int em) =>
-    sh*60 + sm <= eh*60 + em
-        ? ((nyHour > sh or (nyHour == sh and nyMinute >= sm)) and (nyHour < eh or (nyHour == eh and nyMinute < em)))
-        : ((nyHour > sh or (nyHour == sh and nyMinute >= sm)) or (nyHour < eh or (nyHour == eh and nyMinute < em)))
+f_inSession(sh, sm, eh, em) =>
+    sameDay = sh*60 + sm <= eh*60 + em
+    if sameDay
+        ((nyHour > sh or (nyHour == sh and nyMinute >= sm)) and (nyHour < eh or (nyHour == eh and nyMinute < em)))
+    else
+        ((nyHour > sh or (nyHour == sh and nyMinute >= sm)) or (nyHour < eh or (nyHour == eh and nyMinute < em)))
 
 // ==========================
 // 9:00 H1 bias (live candle bias)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -72,20 +72,6 @@ showDebug    = input.bool(false, "Show debug plots")
 showAsiaBox  = input.bool(true, "Show Asia box (pink)")
 showLondonBox= input.bool(true, "Show London box (blue)")
 showWeeklyHL = input.bool(true, "Show Weekly High/Low")
-asiaColor    = input.color(color.fuchsia, "Asia color")
-asiaFillT    = input.int(85, "Asia box transparency", minval=0, maxval=100)
-asiaLineW    = input.int(1, "Asia line width", minval=1, maxval=5)
-londonColor  = input.color(color.blue, "London color")
-londonFillT  = input.int(85, "London box transparency", minval=0, maxval=100)
-londonLineW  = input.int(1, "London line width", minval=1, maxval=5)
-// Level style customization
-showPDLevels = input.bool(true, "Show Previous Day H/L")
-pdHighColor  = input.color(color.new(color.green, 0), "PD High Color")
-pdLowColor   = input.color(color.new(color.red,   0), "PD Low Color")
-pdLineWidth  = input.int(1, "PD Line Width", minval=1, maxval=5)
-weeklyHighColor = input.color(color.new(color.green, 0), "Weekly High Color")
-weeklyLowColor  = input.color(color.new(color.blue,  0), "Weekly Low Color")
-weeklyLineWidth = input.int(1, "Weekly Line Width", minval=1, maxval=5)
 
 // ==========================
 // Time helpers (ET)
@@ -219,12 +205,12 @@ passLong  = (modeStrict ? strictLong  : pragLong)
 passShort = (modeStrict ? strictShort : pragShort)
 
 // ==========================
-// Previous Day High/Low (configurable color/width) via 1D security
+// Previous Day High/Low (robust via 1D security)
 // ==========================
-prevDayHigh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
-prevDayLow  = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
-plot(showPDLevels ? prevDayHigh : na, title="PDH")
-plot(showPDLevels ? prevDayLow  : na, title="PDL")
+pdh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
+pdl = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
+plot(pdh, color=color.new(color.fuchsia, 0), title="PDH")
+plot(pdl, color=color.new(color.fuchsia, 0), title="PDL")
 
 // ==========================
 // Weekly High/Low (previous and current for context)
@@ -298,17 +284,81 @@ if inLondon and not na(londonHighCarry)
     londonHighCarry := math.max(londonHighCarry, high)
     londonLowCarry  := math.min(londonLowCarry,  low)
 
-// Plot lines (editable in Style panel)
-asiaHiPlot   = plot(asiaHighCarry,   title="Asia High")
-asiaLoPlot   = plot(asiaLowCarry,    title="Asia Low")
-londonHiPlot = plot(londonHighCarry, title="London High")
-londonLoPlot = plot(londonLowCarry,  title="London Low")
+// Draw Asia (20:00–00:00) and London (02:00–07:00) as boxes with H/L lines extended right
+var box  asiaBox   = na
+var line asiaHiLn  = na
+var line asiaLoLn  = na
+var int  asiaT0    = na
 
-// Optional fills for session boxes (color editable via Inputs; transparency via Inputs)
-asiaFillColor   = showAsiaBox   and not na(asiaHighCarry)   and not na(asiaLowCarry)   ? color.new(asiaColor,   asiaFillT)   : na
-londonFillColor = showLondonBox and not na(londonHighCarry) and not na(londonLowCarry) ? color.new(londonColor, londonFillT) : na
-fill(asiaHiPlot,   asiaLoPlot,   color=asiaFillColor,   title="Asia Box")
-fill(londonHiPlot, londonLoPlot, color=londonFillColor, title="London Box")
+var box  londonBox = na
+var line londonHiLn= na
+var line londonLoLn= na
+var int  londonT0  = na
+
+// Asia session box and lines
+if inAsia and not inAsia[1]
+    // session start
+    asiaT0 := time
+    // reset extremes at session start
+    asiaHigh := high
+    asiaLow  := low
+    if showAsiaBox
+        asiaBox := box.new(asiaT0, asiaHigh, asiaT0, asiaLow, xloc=xloc.bar_time, bgcolor=color.new(color.fuchsia, 85), border_color=color.fuchsia)
+    // create lines anchored at session start
+    asiaHiLn := line.new(asiaT0, asiaHigh, time, asiaHigh, xloc=xloc.bar_time, extend=extend.none, color=color.fuchsia, width=1)
+    asiaLoLn := line.new(asiaT0, asiaLow,  time, asiaLow,  xloc=xloc.bar_time, extend=extend.none, color=color.fuchsia, width=1)
+
+if inAsia
+    // update extremes
+    asiaHigh := math.max(asiaHigh, high)
+    asiaLow  := math.min(asiaLow,  low)
+    // update box bounds
+    if not na(asiaBox)
+        box.set_right(asiaBox, time)
+        box.set_top(asiaBox,   asiaHigh)
+        box.set_bottom(asiaBox,asiaLow)
+    // update lines (left at start, right at now)
+    if not na(asiaHiLn)
+        line.set_xy1(asiaHiLn, asiaT0, asiaHigh)
+        line.set_xy2(asiaHiLn, time,   asiaHigh)
+    if not na(asiaLoLn)
+        line.set_xy1(asiaLoLn, asiaT0, asiaLow)
+        line.set_xy2(asiaLoLn, time,   asiaLow)
+
+// After session ends, keep extending lines to the right at fixed prices
+if not inAsia and not na(asiaHiLn)
+    line.set_x2(asiaHiLn, time)
+if not inAsia and not na(asiaLoLn)
+    line.set_x2(asiaLoLn, time)
+
+// London session box and lines
+if inLondon and not inLondon[1]
+    londonT0 := time
+    londonHigh := high
+    londonLow  := low
+    if showLondonBox
+        londonBox := box.new(londonT0, londonHigh, londonT0, londonLow, xloc=xloc.bar_time, bgcolor=color.new(color.blue, 85), border_color=color.blue)
+    londonHiLn := line.new(londonT0, londonHigh, time, londonHigh, xloc=xloc.bar_time, extend=extend.none, color=color.blue, width=1)
+    londonLoLn := line.new(londonT0, londonLow,  time, londonLow,  xloc=xloc.bar_time, extend=extend.none, color=color.blue, width=1)
+
+if inLondon
+    londonHigh := math.max(londonHigh, high)
+    londonLow  := math.min(londonLow,  low)
+    if not na(londonBox)
+        box.set_right(londonBox, time)
+        box.set_top(londonBox,   londonHigh)
+        box.set_bottom(londonBox,londonLow)
+    if not na(londonHiLn)
+        line.set_xy1(londonHiLn, londonT0, londonHigh)
+        line.set_xy2(londonHiLn, time,     londonHigh)
+    if not na(londonLoLn)
+        line.set_xy1(londonLoLn, londonT0, londonLow)
+        line.set_xy2(londonLoLn, time,     londonLow)
+
+if not inLondon and not na(londonHiLn)
+    line.set_x2(londonHiLn, time)
+if not inLondon and not na(londonLoLn)
+    line.set_x2(londonLoLn, time)
 
 // Daily open line (start at dailyOpenH:M, stop at dailyCloseH:M) + label
 var line dailyOpenLine = na

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -6,7 +6,7 @@ strategy(title="NY Open AVWAP H1 Bias (MNQ)", shorttitle="NY Open AVWAP H1 Bias"
 // Inputs
 // ==========================
 // Trading window (ET)
-string TZ_NY = "America/New_York"
+const string TZ_NY = "America/New_York"
 inputSessionStartH = input.int(9, "Window start hour (ET)", minval=0, maxval=23)
 inputSessionStartM = input.int(30, "Window start minute (ET)", minval=0, maxval=59)
 inputSessionEndH   = input.int(9, "Window end hour (ET)", minval=0, maxval=23)
@@ -45,15 +45,13 @@ showDebug    = input.bool(false, "Show debug plots")
 // ==========================
 // Time helpers (ET)
 // ==========================
-nyHour   = hour(time, TZ_NY)
-nyMinute = minute(time, TZ_NY)
-nyDoy    = dayofyear(time, TZ_NY)
-nyIsNewDay = ta.change(nyDoy)
+nyHour      = hour(time, TZ_NY)
+nyMinute    = minute(time, TZ_NY)
+nyDayOfMon  = dayofmonth(time, TZ_NY)
+nyIsNewDay  = ta.change(nyDayOfMon)
 
-inWindow = (
-     (nyHour > inputSessionStartH or (nyHour == inputSessionStartH and nyMinute >= inputSessionStartM)) and
-     (nyHour < inputSessionEndH   or (nyHour == inputSessionEndH   and nyMinute <= inputSessionEndM))
-)
+// Keep it on a single line to avoid parser quirks
+inWindow = (nyHour > inputSessionStartH or (nyHour == inputSessionStartH and nyMinute >= inputSessionStartM)) and (nyHour < inputSessionEndH or (nyHour == inputSessionEndH and nyMinute <= inputSessionEndM))
 
 // ==========================
 // 9:00 H1 bias (live candle bias)
@@ -190,11 +188,11 @@ withinDistShort = not na(avwap_open) and (avwap_open - close) <= maxDistATR * at
 // ==========================
 var bool tradedLongToday  = false
 var bool tradedShortToday = false
-var int  lastNYDoy = na
-if na(lastNYDoy) or nyIsNewDay
+var int  lastNYDom = na
+if na(lastNYDom) or nyIsNewDay
     tradedLongToday  := false
     tradedShortToday := false
-    lastNYDoy := nyDoy
+    lastNYDom := nyDayOfMon
 
 canLong  = inWindow and passLong  and not tradedLongToday
 canShort = inWindow and passShort and not tradedShortToday

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -8,9 +8,9 @@ strategy("NY Open AVWAP H1 Bias (MNQ)", overlay=true, initial_capital=100000, py
 // Trading window (ET)
 string TZ_NY = "America/New_York"
 inputSessionStartH = input.int(9, "Window start hour (ET)", minval=0, maxval=23)
-inputSessionStartM = input.int(30, "Window start minute (ET)", minval=0, maxval=59)
-inputSessionEndH   = input.int(9, "Window end hour (ET)", minval=0, maxval=23)
-inputSessionEndM   = input.int(50, "Window end minute (ET)", minval=0, maxval=59)
+inputSessionStartM = input.int(50, "Window start minute (ET)", minval=0, maxval=59)
+inputSessionEndH   = input.int(10, "Window end hour (ET)", minval=0, maxval=23)
+inputSessionEndM   = input.int(10, "Window end minute (ET)", minval=0, maxval=59)
 
 // Anchors (ET)
 asiaH   = input.int(20, "Asia anchor hour (ET)", minval=0, maxval=23)
@@ -23,6 +23,30 @@ openH   = input.int(9,  "9:30 anchor hour (ET)", minval=0, maxval=23)
 openM   = input.int(30, "9:30 anchor minute (ET)", minval=0, maxval=59)
 tenH    = input.int(10, "10:00 anchor hour (ET)", minval=0, maxval=23)
 tenM    = input.int(0,  "10:00 anchor minute (ET)", minval=0, maxval=59)
+
+// Session windows (manual override friendly)
+premStartH = input.int(18, "Premarket start hour (ET)", minval=0, maxval=23)
+premStartM = input.int(0,  "Premarket start minute (ET)", minval=0, maxval=59)
+premEndH   = input.int(9,  "Premarket end hour (ET)", minval=0, maxval=23)
+premEndM   = input.int(30, "Premarket end minute (ET)", minval=0, maxval=59)
+
+asiaStartH = input.int(20, "Asia start hour (ET)", minval=0, maxval=23)
+asiaStartM = input.int(0,  "Asia start minute (ET)", minval=0, maxval=59)
+asiaEndH   = input.int(0,  "Asia end hour (ET)", minval=0, maxval=23)
+asiaEndM   = input.int(0,  "Asia end minute (ET)", minval=0, maxval=59)
+
+londonStartH = input.int(2, "London start hour (ET)", minval=0, maxval=23)
+londonStartM = input.int(0, "London start minute (ET)", minval=0, maxval=59)
+londonEndH   = input.int(7, "London end hour (ET)", minval=0, maxval=23)
+londonEndM   = input.int(0, "London end minute (ET)", minval=0, maxval=59)
+
+// Manual premarket H/L override
+useManualPremHL   = input.bool(false, "Use manual Premarket High/Low")
+manualPremHigh    = input.float(0.0, "Premarket High (manual)")
+manualPremLow     = input.float(0.0, "Premarket Low (manual)")
+
+// Daily open line toggle
+showDailyOpenLine = input.bool(true, "Show Daily Open line (18:00 ET)")
 
 // Bias mode
 modeStrict = input.bool(true, "Strict mode (all AVWAPs aligned; else Pragmatic mode)")
@@ -52,6 +76,12 @@ nyIsNewDay  = ta.change(nyDayOfMon)
 
 // Keep it on a single line to avoid parser quirks
 inWindow = (nyHour > inputSessionStartH or (nyHour == inputSessionStartH and nyMinute >= inputSessionStartM)) and (nyHour < inputSessionEndH or (nyHour == inputSessionEndH and nyMinute <= inputSessionEndM))
+
+// Helper: session membership handling midnight-crossing sessions
+f_inSession(int sh, int sm, int eh, int em) =>
+    sh*60 + sm <= eh*60 + em
+        ? ((nyHour > sh or (nyHour == sh and nyMinute >= sm)) and (nyHour < eh or (nyHour == eh and nyMinute < em)))
+        : ((nyHour > sh or (nyHour == sh and nyMinute >= sm)) or (nyHour < eh or (nyHour == eh and nyMinute < em)))
 
 // ==========================
 // 9:00 H1 bias (live candle bias)
@@ -161,6 +191,69 @@ pragShort = biasDown and belowOpen   and alignedCountShort >= minAligned
 
 passLong  = (modeStrict ? strictLong  : pragLong)
 passShort = (modeStrict ? strictShort : pragShort)
+
+// ==========================
+// Previous Day High/Low and Session High/Low + Boxes
+// ==========================
+// Previous day (RTH day aligned with TZ_NY daily)
+var float pdHigh = na
+var float pdLow  = na
+var int   curDay = nyDayOfMon
+if ta.change(time("D", TZ_NY))
+    pdHigh := high[1]
+    pdLow  := low[1]
+// Plot PDH/PDL
+plot(pdHigh, color=color.new(color.fuchsia, 0), title="PDH")
+plot(pdLow,  color=color.new(color.fuchsia, 0), title="PDL")
+
+// Premarket (18:00–9:30 ET by default)
+inPrem = f_inSession(premStartH, premStartM, premEndH, premEndM)
+var float premHigh = na
+var float premLow  = na
+if barstate.isfirst or ta.change(time("D", TZ_NY))
+    premHigh := na
+    premLow  := na
+premHigh := inPrem and (na(premHigh) or high > premHigh) ? high : premHigh
+premLow  := inPrem and (na(premLow)  or low  < premLow)  ? low  : premLow
+premHiPlot = useManualPremHL and manualPremHigh != 0.0 ? manualPremHigh : premHigh
+premLoPlot = useManualPremHL and manualPremLow  != 0.0 ? manualPremLow  : premLow
+plot(premHiPlot, color=color.new(color.yellow, 0), title="Premarket High")
+plot(premLoPlot, color=color.new(color.yellow, 0), title="Premarket Low")
+
+// Asia session hi/low and box
+inAsia = f_inSession(asiaStartH, asiaStartM, asiaEndH, asiaEndM)
+var float asiaHigh = na
+var float asiaLow  = na
+if barstate.isfirst or ta.change(time("D", TZ_NY))
+    asiaHigh := na
+    asiaLow  := na
+asiaHigh := inAsia and (na(asiaHigh) or high > asiaHigh) ? high : asiaHigh
+asiaLow  := inAsia and (na(asiaLow)  or low  < asiaLow)  ? low  : asiaLow
+
+// London session hi/low and box
+inLondon = f_inSession(londonStartH, londonStartM, londonEndH, londonEndM)
+var float londonHigh = na
+var float londonLow  = na
+if barstate.isfirst or ta.change(time("D", TZ_NY))
+    londonHigh := na
+    londonLow  := na
+londonHigh := inLondon and (na(londonHigh) or high > londonHigh) ? high : londonHigh
+londonLow  := inLondon and (na(londonLow)  or low  < londonLow)  ? low  : londonLow
+
+// Draw session boxes (using fill between highs/lows)
+asiaHiPlot  = plot(asiaHigh,  color=color.new(color.teal, 70), title="Asia High")
+asiaLoPlot  = plot(asiaLow,   color=color.new(color.teal, 70), title="Asia Low")
+londonHiPlot= plot(londonHigh,color=color.new(color.blue, 70), title="London High")
+londonLoPlot= plot(londonLow, color=color.new(color.blue, 70), title="London Low")
+premHiFill  = plot(premHiPlot,color=color.new(color.orange,70), title="Premarket High (box)")
+premLoFill  = plot(premLoPlot,color=color.new(color.orange,70), title="Premarket Low (box)")
+fill(asiaHiPlot,  asiaLoPlot,  color=color.new(color.teal,  85), title="Asia Box")
+fill(londonHiPlot,londonLoPlot,color=color.new(color.blue,  85), title="London Box")
+fill(premHiFill,  premLoFill,  color=color.new(color.orange,85), title="Premarket Box")
+
+// Daily open line at 18:00 ET
+if showDailyOpenLine and (nyHour == 18 and nyMinute == 0)
+    line.new(bar_index, open, bar_index+1, open, xloc=xloc.bar_index, extend=extend.right, color=color.black, style=line.style_dotted, width=2)
 
 // ==========================
 // Trigger: Reclaim AVWAP 9:30 (+ optional BOS)

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -85,6 +85,9 @@ f_inSession(sh, sm, eh, em) =>
     else
         ((nyHour > sh or (nyHour == sh and nyMinute >= sm)) or (nyHour < eh or (nyHour == eh and nyMinute < em)))
 
+// Daily change flag (compute once per bar)
+newDay = ta.change(time("D", TZ_NY)) != 0
+
 // ==========================
 // 9:00 H1 bias (live candle bias)
 // ==========================
@@ -201,7 +204,7 @@ passShort = (modeStrict ? strictShort : pragShort)
 var float pdHigh = na
 var float pdLow  = na
 var int   curDay = nyDayOfMon
-if ta.change(time("D", TZ_NY))
+if newDay
     pdHigh := high[1]
     pdLow  := low[1]
 // Plot PDH/PDL
@@ -212,7 +215,7 @@ plot(pdLow,  color=color.new(color.fuchsia, 0), title="PDL")
 inPrem = f_inSession(premStartH, premStartM, premEndH, premEndM)
 var float premHigh = na
 var float premLow  = na
-if barstate.isfirst or ta.change(time("D", TZ_NY))
+if barstate.isfirst or newDay
     premHigh := na
     premLow  := na
 premHigh := inPrem and (na(premHigh) or high > premHigh) ? high : premHigh
@@ -226,7 +229,7 @@ plot(premLoPlot, color=color.new(color.yellow, 0), title="Premarket Low")
 inAsia = f_inSession(asiaStartH, asiaStartM, asiaEndH, asiaEndM)
 var float asiaHigh = na
 var float asiaLow  = na
-if barstate.isfirst or ta.change(time("D", TZ_NY))
+if barstate.isfirst or newDay
     asiaHigh := na
     asiaLow  := na
 asiaHigh := inAsia and (na(asiaHigh) or high > asiaHigh) ? high : asiaHigh
@@ -236,7 +239,7 @@ asiaLow  := inAsia and (na(asiaLow)  or low  < asiaLow)  ? low  : asiaLow
 inLondon = f_inSession(londonStartH, londonStartM, londonEndH, londonEndM)
 var float londonHigh = na
 var float londonLow  = na
-if barstate.isfirst or ta.change(time("D", TZ_NY))
+if barstate.isfirst or newDay
     londonHigh := na
     londonLow  := na
 londonHigh := inLondon and (na(londonHigh) or high > londonHigh) ? high : londonHigh
@@ -255,6 +258,10 @@ fill(premHiFill,  premLoFill,  color=color.new(color.orange,85), title="Premarke
 
 // Daily open line at 18:00 ET
 if showDailyOpenLine and (nyHour == 18 and nyMinute == 0)
+    doLine = true
+else
+    doLine = false
+if doLine
     line.new(bar_index, open, bar_index+1, open, xloc=xloc.bar_index, extend=extend.right, color=color.black, style=line.style_dotted, width=2)
 
 // ==========================

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -69,6 +69,9 @@ timeStopMin  = input.int(15, "Time-stop minutes (exit if not hit TP/SL)", minval
 // Visuals
 showLabels   = input.bool(true, "Show entry/exit labels")
 showDebug    = input.bool(false, "Show debug plots")
+showAsiaBox  = input.bool(true, "Show Asia box (pink)")
+showLondonBox= input.bool(true, "Show London box (blue)")
+showWeeklyHL = input.bool(true, "Show Weekly High/Low")
 
 // ==========================
 // Time helpers (ET)
@@ -209,6 +212,16 @@ pdl = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.looka
 plot(pdh, color=color.new(color.fuchsia, 0), title="PDH")
 plot(pdl, color=color.new(color.fuchsia, 0), title="PDL")
 
+// ==========================
+// Weekly High/Low (previous and current for context)
+// ==========================
+wh  = request.security(syminfo.tickerid, "1W", high,   lookahead=barmerge.lookahead_off)
+wl  = request.security(syminfo.tickerid, "1W", low,    lookahead=barmerge.lookahead_off)
+pwh = request.security(syminfo.tickerid, "1W", high[1],lookahead=barmerge.lookahead_off)
+pwl = request.security(syminfo.tickerid, "1W", low[1], lookahead=barmerge.lookahead_off)
+plot(showWeeklyHL ? pwh : na, color=color.new(color.green, 0), title="Prev Weekly High")
+plot(showWeeklyHL ? pwl : na, color=color.new(color.blue,  0), title="Prev Weekly Low")
+
 // Premarket (18:00–9:30 ET by default)
 inPrem = f_inSession(premStartH, premStartM, premEndH, premEndM)
 var float premHigh = na
@@ -243,11 +256,15 @@ if barstate.isfirst or newDay
 londonHigh := inLondon and (na(londonHigh) or high > londonHigh) ? high : londonHigh
 londonLow  := inLondon and (na(londonLow)  or low  < londonLow)  ? low  : londonLow
 
-// Draw session boxes (using fill between highs/lows)
-asiaHiPlot  = plot(asiaHigh,  color=color.new(color.teal,  0), title="Asia High")
-asiaLoPlot  = plot(asiaLow,   color=color.new(color.teal,  0), title="Asia Low")
+// Draw session lines and optional boxes
+asiaHiPlot  = plot(asiaHigh,  color=color.new(color.pink,  0), title="Asia High")
+asiaLoPlot  = plot(asiaLow,   color=color.new(color.pink,  0), title="Asia Low")
 londonHiPlot= plot(londonHigh,color=color.new(color.blue,  0), title="London High")
 londonLoPlot= plot(londonLow, color=color.new(color.blue,  0), title="London Low")
+if showAsiaBox and inAsia and not na(asiaHigh) and not na(asiaLow)
+    fill(asiaHiPlot, asiaLoPlot, color=color.new(color.pink, 85), title="Asia Box")
+if showLondonBox and inLondon and not na(londonHigh) and not na(londonLow)
+    fill(londonHiPlot, londonLoPlot, color=color.new(color.blue, 85), title="London Box")
 
 // Daily open line (start at dailyOpenH:M, stop at dailyCloseH:M) + label
 var line dailyOpenLine = na

--- a/ny_open_avwap_h1_bias.pine
+++ b/ny_open_avwap_h1_bias.pine
@@ -257,14 +257,14 @@ londonHigh := inLondon and (na(londonHigh) or high > londonHigh) ? high : london
 londonLow  := inLondon and (na(londonLow)  or low  < londonLow)  ? low  : londonLow
 
 // Draw session lines and optional boxes
-asiaHiPlot  = plot(asiaHigh,  color=color.new(color.pink,  0), title="Asia High")
-asiaLoPlot  = plot(asiaLow,   color=color.new(color.pink,  0), title="Asia Low")
-londonHiPlot= plot(londonHigh,color=color.new(color.blue,  0), title="London High")
-londonLoPlot= plot(londonLow, color=color.new(color.blue,  0), title="London Low")
-if showAsiaBox and inAsia and not na(asiaHigh) and not na(asiaLow)
-    fill(asiaHiPlot, asiaLoPlot, color=color.new(color.pink, 85), title="Asia Box")
-if showLondonBox and inLondon and not na(londonHigh) and not na(londonLow)
-    fill(londonHiPlot, londonLoPlot, color=color.new(color.blue, 85), title="London Box")
+asiaHiPlot  = plot(asiaHigh,  color=color.new(color.fuchsia, 0), title="Asia High")
+asiaLoPlot  = plot(asiaLow,   color=color.new(color.fuchsia, 0), title="Asia Low")
+londonHiPlot= plot(londonHigh,color=color.new(color.blue,    0), title="London High")
+londonLoPlot= plot(londonLow, color=color.new(color.blue,    0), title="London Low")
+asiaFillColor   = showAsiaBox   and not na(asiaHigh)   and not na(asiaLow)   ? color.new(color.fuchsia, 85) : na
+londonFillColor = showLondonBox and not na(londonHigh) and not na(londonLow) ? color.new(color.blue,    85) : na
+fill(asiaHiPlot,   asiaLoPlot,   color=asiaFillColor,   title="Asia Box")
+fill(londonHiPlot, londonLoPlot, color=londonFillColor, title="London Box")
 
 // Daily open line (start at dailyOpenH:M, stop at dailyCloseH:M) + label
 var line dailyOpenLine = na

--- a/ny_open_avwap_h1_bias_stable.pine
+++ b/ny_open_avwap_h1_bias_stable.pine
@@ -1,0 +1,510 @@
+//@version=6
+// Strategy declaration (kept minimal for compatibility across editors)
+strategy("NY Open AVWAP H1 Bias (MNQ)", overlay=true, initial_capital=100000, pyramiding=0, calc_on_order_fills=true, calc_on_every_tick=true)
+
+// ==========================
+// Inputs
+// ==========================
+// Trading window (ET)
+string TZ_NY = "America/New_York"
+inputSessionStartH = input.int(9, "Window start hour (ET)", minval=0, maxval=23)
+inputSessionStartM = input.int(50, "Window start minute (ET)", minval=0, maxval=59)
+inputSessionEndH   = input.int(10, "Window end hour (ET)", minval=0, maxval=23)
+inputSessionEndM   = input.int(10, "Window end minute (ET)", minval=0, maxval=59)
+
+// Anchors (ET)
+asiaH   = input.int(20, "Asia anchor hour (ET)", minval=0, maxval=23)
+asiaM   = input.int(0,  "Asia anchor minute (ET)", minval=0, maxval=59)
+londonH = input.int(3,  "London anchor hour (ET)", minval=0, maxval=23)
+londonM = input.int(0,  "London anchor minute (ET)", minval=0, maxval=59)
+preH    = input.int(8,  "8:00 anchor hour (ET)", minval=0, maxval=23)
+preM    = input.int(0,  "8:00 anchor minute (ET)", minval=0, maxval=59)
+openH   = input.int(9,  "9:30 anchor hour (ET)", minval=0, maxval=23)
+openM   = input.int(30, "9:30 anchor minute (ET)", minval=0, maxval=59)
+tenH    = input.int(10, "10:00 anchor hour (ET)", minval=0, maxval=23)
+tenM    = input.int(0,  "10:00 anchor minute (ET)", minval=0, maxval=59)
+
+// Session windows (manual override friendly)
+premStartH = input.int(18, "Premarket start hour (ET)", minval=0, maxval=23)
+premStartM = input.int(0,  "Premarket start minute (ET)", minval=0, maxval=59)
+premEndH   = input.int(9,  "Premarket end hour (ET)", minval=0, maxval=23)
+premEndM   = input.int(30, "Premarket end minute (ET)", minval=0, maxval=59)
+
+asiaStartH = input.int(20, "Asia start hour (ET)", minval=0, maxval=23)
+asiaStartM = input.int(0,  "Asia start minute (ET)", minval=0, maxval=59)
+asiaEndH   = input.int(0,  "Asia end hour (ET)", minval=0, maxval=23)
+asiaEndM   = input.int(0,  "Asia end minute (ET)", minval=0, maxval=59)
+
+londonStartH = input.int(2, "London start hour (ET)", minval=0, maxval=23)
+londonStartM = input.int(0, "London start minute (ET)", minval=0, maxval=59)
+londonEndH   = input.int(7, "London end hour (ET)", minval=0, maxval=23)
+londonEndM   = input.int(0, "London end minute (ET)", minval=0, maxval=59)
+
+// Manual premarket H/L override
+useManualPremHL   = input.bool(false, "Use manual Premarket High/Low")
+manualPremHigh    = input.float(0.0, "Premarket High (manual)")
+manualPremLow     = input.float(0.0, "Premarket Low (manual)")
+
+// Daily open line toggle and timing
+showDailyOpenLine = input.bool(true, "Show Daily Open line")
+dailyOpenH = input.int(18, "Daily open hour (ET)", minval=0, maxval=23)
+dailyOpenM = input.int(0,  "Daily open minute (ET)", minval=0, maxval=59)
+dailyCloseH = input.int(17, "Daily close hour (ET)", minval=0, maxval=23)
+dailyCloseM = input.int(0,  "Daily close minute (ET)", minval=0, maxval=59)
+
+// Bias mode
+modeStrict = input.bool(true, "Strict mode (all AVWAPs aligned; else Pragmatic mode)")
+minAligned = input.int(3, "Pragmatic: minimum AVWAPs aligned (out of Asia/London/8:00/9:30)", minval=1, maxval=4)
+requireBos = input.bool(false, "Require BOS (break of internal swing) with reclaim")
+
+// Risk management
+qtyContracts = input.int(1, "Contracts", minval=1)
+atrLen       = input.int(14, "ATR length", minval=1)
+atrMult      = input.float(0.3, "ATR buffer multiplier", step=0.05)
+minTicksBuf  = input.int(10, "Minimum buffer (ticks)", minval=0)
+rMultiple    = input.float(2.0, "Take profit multiple (R)", step=0.25)
+moveToBE     = input.bool(true, "Move stop to BE at 1R")
+timeStopMin  = input.int(15, "Time-stop minutes (exit if not hit TP/SL)", minval=1)
+
+// Visuals
+showLabels   = input.bool(true, "Show entry/exit labels")
+showDebug    = input.bool(false, "Show debug plots")
+showAsiaBox  = input.bool(true, "Show Asia box (pink)")
+showLondonBox= input.bool(true, "Show London box (blue)")
+showWeeklyHL = input.bool(true, "Show Weekly High/Low")
+
+// ==========================
+// Time helpers (ET)
+// ==========================
+nyHour      = hour(time, TZ_NY)
+nyMinute    = minute(time, TZ_NY)
+nyDayOfMon  = dayofmonth(time, TZ_NY)
+nyIsNewDay  = ta.change(nyDayOfMon)
+
+// Keep it on a single line to avoid parser quirks
+inWindow = (nyHour > inputSessionStartH or (nyHour == inputSessionStartH and nyMinute >= inputSessionStartM)) and (nyHour < inputSessionEndH or (nyHour == inputSessionEndH and nyMinute <= inputSessionEndM))
+
+// Helper: session membership handling midnight-crossing sessions
+f_inSession(sh, sm, eh, em) =>
+    sameDay = sh*60 + sm <= eh*60 + em
+    if sameDay
+        ((nyHour > sh or (nyHour == sh and nyMinute >= sm)) and (nyHour < eh or (nyHour == eh and nyMinute < em)))
+    else
+        ((nyHour > sh or (nyHour == sh and nyMinute >= sm)) or (nyHour < eh or (nyHour == eh and nyMinute < em)))
+
+// Daily change flag (compute once per bar)
+newDay = ta.change(time("D", TZ_NY)) != 0
+
+// ==========================
+// 9:00 H1 bias (live candle bias)
+// ==========================
+var float ny9Open = na
+isNY9OpenBar = (nyHour == 9 and nyMinute == 0)
+if isNY9OpenBar
+    ny9Open := open
+biasUp   = not na(ny9Open) and close > ny9Open
+biasDown = not na(ny9Open) and close < ny9Open
+
+// ==========================
+// Anchored VWAP builders (per-anchor state)
+// ==========================
+var float cumPV_asia   = na
+var float cumV_asia    = na
+var float avwap_asia   = na
+var float cumPV_london = na
+var float cumV_london  = na
+var float avwap_london = na
+var float cumPV_pre    = na
+var float cumV_pre     = na
+var float avwap_pre    = na
+var float cumPV_open   = na
+var float cumV_open    = na
+var float avwap_open   = na
+var float cumPV_ten    = na
+var float cumV_ten     = na
+var float avwap_ten    = na
+
+source = hlc3
+pv     = source * volume
+
+isAsiaAnchor   = (nyHour == asiaH   and nyMinute == asiaM)
+isLondonAnchor = (nyHour == londonH and nyMinute == londonM)
+isPreAnchor    = (nyHour == preH    and nyMinute == preM)
+isOpenAnchor   = (nyHour == openH   and nyMinute == openM)
+isTenAnchor    = (nyHour == tenH    and nyMinute == tenM)
+
+// Update Asia AVWAP
+if isAsiaAnchor or na(cumPV_asia)
+    cumPV_asia := pv
+    cumV_asia  := volume
+else
+    cumPV_asia += pv
+    cumV_asia  += volume
+avwap_asia := cumPV_asia / cumV_asia
+
+// Update London AVWAP
+if isLondonAnchor or na(cumPV_london)
+    cumPV_london := pv
+    cumV_london  := volume
+else
+    cumPV_london += pv
+    cumV_london  += volume
+avwap_london := cumPV_london / cumV_london
+
+// Update 8:00 AVWAP
+if isPreAnchor or na(cumPV_pre)
+    cumPV_pre := pv
+    cumV_pre  := volume
+else
+    cumPV_pre += pv
+    cumV_pre  += volume
+avwap_pre := cumPV_pre / cumV_pre
+
+// Update 9:30 AVWAP
+if isOpenAnchor or na(cumPV_open)
+    cumPV_open := pv
+    cumV_open  := volume
+else
+    cumPV_open += pv
+    cumV_open  += volume
+avwap_open := cumPV_open / cumV_open
+
+// Update 10:00 AVWAP
+if isTenAnchor or na(cumPV_ten)
+    cumPV_ten := pv
+    cumV_ten  := volume
+else
+    cumPV_ten += pv
+    cumV_ten  += volume
+avwap_ten := cumPV_ten / cumV_ten
+
+// ==========================
+// Alignment logic (Strict vs Pragmatic)
+// ==========================
+// Only consider anchors available before/within the entry window (ignore 10:00 for 9:30-9:50 decisions)
+aboveAsia   = not na(avwap_asia)   and close > avwap_asia
+aboveLondon = not na(avwap_london) and close > avwap_london
+abovePre    = not na(avwap_pre)    and close > avwap_pre
+aboveOpen   = not na(avwap_open)   and close > avwap_open
+
+belowAsia   = not na(avwap_asia)   and close < avwap_asia
+belowLondon = not na(avwap_london) and close < avwap_london
+belowPre    = not na(avwap_pre)    and close < avwap_pre
+belowOpen   = not na(avwap_open)   and close < avwap_open
+
+strictLong  = biasUp   and aboveAsia   and aboveLondon and abovePre and aboveOpen
+strictShort = biasDown and belowAsia   and belowLondon and belowPre and belowOpen
+
+alignedCountLong  = (aboveAsia?1:0) + (aboveLondon?1:0) + (abovePre?1:0) + (aboveOpen?1:0)
+alignedCountShort = (belowAsia?1:0) + (belowLondon?1:0) + (belowPre?1:0) + (belowOpen?1:0)
+
+pragLong  = biasUp   and aboveOpen   and alignedCountLong  >= minAligned
+pragShort = biasDown and belowOpen   and alignedCountShort >= minAligned
+
+passLong  = (modeStrict ? strictLong  : pragLong)
+passShort = (modeStrict ? strictShort : pragShort)
+
+// ==========================
+// Previous Day High/Low (robust via 1D security)
+// ==========================
+pdh = request.security(syminfo.tickerid, "1D", high[1], lookahead=barmerge.lookahead_off)
+pdl = request.security(syminfo.tickerid, "1D", low[1],  lookahead=barmerge.lookahead_off)
+plot(pdh, color=color.new(color.fuchsia, 0), title="PDH")
+plot(pdl, color=color.new(color.fuchsia, 0), title="PDL")
+
+// ==========================
+// Weekly High/Low (previous and current for context)
+// ==========================
+wh  = request.security(syminfo.tickerid, "1W", high,   lookahead=barmerge.lookahead_off)
+wl  = request.security(syminfo.tickerid, "1W", low,    lookahead=barmerge.lookahead_off)
+pwh = request.security(syminfo.tickerid, "1W", high[1],lookahead=barmerge.lookahead_off)
+pwl = request.security(syminfo.tickerid, "1W", low[1], lookahead=barmerge.lookahead_off)
+plot(showWeeklyHL ? pwh : na, color=color.new(color.green, 0), title="Prev Weekly High")
+plot(showWeeklyHL ? pwl : na, color=color.new(color.blue,  0), title="Prev Weekly Low")
+
+// Premarket (18:00–9:30 ET by default)
+inPrem = f_inSession(premStartH, premStartM, premEndH, premEndM)
+var float premHigh = na
+var float premLow  = na
+if barstate.isfirst or newDay
+    premHigh := na
+    premLow  := na
+premHigh := inPrem and (na(premHigh) or high > premHigh) ? high : premHigh
+premLow  := inPrem and (na(premLow)  or low  < premLow)  ? low  : premLow
+premHiPlot = useManualPremHL and manualPremHigh != 0.0 ? manualPremHigh : premHigh
+premLoPlot = useManualPremHL and manualPremLow  != 0.0 ? manualPremLow  : premLow
+plot(premHiPlot, color=color.new(color.orange, 0), title="Premarket High")
+plot(premLoPlot, color=color.new(color.orange, 0), title="Premarket Low")
+
+// Asia session hi/low and box
+inAsia = f_inSession(asiaStartH, asiaStartM, asiaEndH, asiaEndM)
+var float asiaHigh = na
+var float asiaLow  = na
+if barstate.isfirst or newDay
+    asiaHigh := na
+    asiaLow  := na
+asiaHigh := inAsia and (na(asiaHigh) or high > asiaHigh) ? high : asiaHigh
+asiaLow  := inAsia and (na(asiaLow)  or low  < asiaLow)  ? low  : asiaLow
+
+// London session hi/low and box
+inLondon = f_inSession(londonStartH, londonStartM, londonEndH, londonEndM)
+var float londonHigh = na
+var float londonLow  = na
+if barstate.isfirst or newDay
+    londonHigh := na
+    londonLow  := na
+londonHigh := inLondon and (na(londonHigh) or high > londonHigh) ? high : londonHigh
+londonLow  := inLondon and (na(londonLow)  or low  < londonLow)  ? low  : londonLow
+
+// Draw Asia (20:00–00:00) and London (02:00–07:00) as boxes with H/L lines extended right
+var box  asiaBox   = na
+var line asiaHiLn  = na
+var line asiaLoLn  = na
+var int  asiaT0    = na
+
+var box  londonBox = na
+var line londonHiLn= na
+var line londonLoLn= na
+var int  londonT0  = na
+
+// Asia session box and lines
+if inAsia and not inAsia[1]
+    // session start
+    asiaT0 := time
+    // reset extremes at session start
+    asiaHigh := high
+    asiaLow  := low
+    if showAsiaBox
+        asiaBox := box.new(asiaT0, asiaHigh, asiaT0, asiaLow, xloc=xloc.bar_time, bgcolor=color.new(color.fuchsia, 85), border_color=color.fuchsia)
+    // create lines anchored at session start
+    asiaHiLn := line.new(asiaT0, asiaHigh, time, asiaHigh, xloc=xloc.bar_time, extend=extend.none, color=color.fuchsia, width=1)
+    asiaLoLn := line.new(asiaT0, asiaLow,  time, asiaLow,  xloc=xloc.bar_time, extend=extend.none, color=color.fuchsia, width=1)
+
+if inAsia
+    // update extremes
+    asiaHigh := math.max(asiaHigh, high)
+    asiaLow  := math.min(asiaLow,  low)
+    // update box bounds
+    if not na(asiaBox)
+        box.set_right(asiaBox, time)
+        box.set_top(asiaBox,   asiaHigh)
+        box.set_bottom(asiaBox,asiaLow)
+    // update lines (left at start, right at now)
+    if not na(asiaHiLn)
+        line.set_xy1(asiaHiLn, asiaT0, asiaHigh)
+        line.set_xy2(asiaHiLn, time,   asiaHigh)
+    if not na(asiaLoLn)
+        line.set_xy1(asiaLoLn, asiaT0, asiaLow)
+        line.set_xy2(asiaLoLn, time,   asiaLow)
+
+// After session ends, keep extending lines to the right at fixed prices
+if not inAsia and not na(asiaHiLn)
+    line.set_x2(asiaHiLn, time)
+if not inAsia and not na(asiaLoLn)
+    line.set_x2(asiaLoLn, time)
+
+// London session box and lines
+if inLondon and not inLondon[1]
+    londonT0 := time
+    londonHigh := high
+    londonLow  := low
+    if showLondonBox
+        londonBox := box.new(londonT0, londonHigh, londonT0, londonLow, xloc=xloc.bar_time, bgcolor=color.new(color.blue, 85), border_color=color.blue)
+    londonHiLn := line.new(londonT0, londonHigh, time, londonHigh, xloc=xloc.bar_time, extend=extend.none, color=color.blue, width=1)
+    londonLoLn := line.new(londonT0, londonLow,  time, londonLow,  xloc=xloc.bar_time, extend=extend.none, color=color.blue, width=1)
+
+if inLondon
+    londonHigh := math.max(londonHigh, high)
+    londonLow  := math.min(londonLow,  low)
+    if not na(londonBox)
+        box.set_right(londonBox, time)
+        box.set_top(londonBox,   londonHigh)
+        box.set_bottom(londonBox,londonLow)
+    if not na(londonHiLn)
+        line.set_xy1(londonHiLn, londonT0, londonHigh)
+        line.set_xy2(londonHiLn, time,     londonHigh)
+    if not na(londonLoLn)
+        line.set_xy1(londonLoLn, londonT0, londonLow)
+        line.set_xy2(londonLoLn, time,     londonLow)
+
+if not inLondon and not na(londonHiLn)
+    line.set_x2(londonHiLn, time)
+if not inLondon and not na(londonLoLn)
+    line.set_x2(londonLoLn, time)
+
+// Daily open line (start at dailyOpenH:M, stop at dailyCloseH:M) + label
+var line dailyOpenLine = na
+var label dailyOpenLabel = na
+var bool dailyOpenActive = false
+isDailyOpenMinute  = (nyHour == dailyOpenH and nyMinute == dailyOpenM)
+isDailyCloseMinute = (nyHour == dailyCloseH and nyMinute == dailyCloseM)
+
+if showDailyOpenLine
+    // Start new line at open minute
+    if isDailyOpenMinute and not isDailyOpenMinute[1]
+        dailyOpenLine := line.new(time, open, time, open, xloc=xloc.bar_time, extend=extend.none, color=color.black, style=line.style_dotted, width=2)
+        dailyOpenLabel := label.new(time, open, "Daily Open", xloc=xloc.bar_time, style=label.style_label_left, color=color.new(color.white, 100), textcolor=color.black, size=size.tiny)
+        dailyOpenActive := true
+    // Extend line and keep label aligned until close minute
+    if dailyOpenActive and not na(dailyOpenLine)
+        line.set_x2(dailyOpenLine, time)
+        if not na(dailyOpenLabel)
+            label.set_x(dailyOpenLabel, time)
+            label.set_y(dailyOpenLabel, line.get_y1(dailyOpenLine))
+    // Stop extending at close minute
+    if isDailyCloseMinute and not isDailyCloseMinute[1] and dailyOpenActive and not na(dailyOpenLine)
+        line.set_x2(dailyOpenLine, time)
+        dailyOpenActive := false
+
+// ==========================
+// Trigger: Reclaim AVWAP 9:30 (+ optional BOS)
+// ==========================
+reclaimLong  = ta.crossover(close, avwap_open)
+reclaimShort = ta.crossunder(close, avwap_open)
+
+// Swings (for BOS and stops)
+left  = 2
+right = 2
+ph = ta.pivothigh(high, left, right)
+pl = ta.pivotlow(low, left, right)
+
+var float lastSwingHigh = na
+var float lastSwingLow  = na
+if not na(ph)
+    lastSwingHigh := ph
+if not na(pl)
+    lastSwingLow := pl
+
+bosLong  = not na(lastSwingHigh) and close > lastSwingHigh
+bosShort = not na(lastSwingLow)  and close < lastSwingLow
+
+triggerLong  = reclaimLong  and (requireBos ? bosLong  : true)
+triggerShort = reclaimShort and (requireBos ? bosShort : true)
+
+// Distance control: avoid chasing too far from AVWAP 9:30 (optional)
+atr = ta.atr(atrLen)
+maxDistATR = input.float(1.0, "Max distance from 9:30 AVWAP (ATR units)", step=0.1)
+withinDistLong  = not na(avwap_open) and (close - avwap_open) <= maxDistATR * atr
+withinDistShort = not na(avwap_open) and (avwap_open - close) <= maxDistATR * atr
+
+// ==========================
+// Per-day trade limits (NY day)
+// ==========================
+var bool tradedLongToday  = false
+var bool tradedShortToday = false
+var int  lastNYDom = na
+// Detect new NY day using daily time change; cast to bool
+bool isNewSessionBar = ta.change(time("D", TZ_NY)) != 0
+
+// Initialize on first bar
+if barstate.isfirst
+    tradedLongToday  := false
+    tradedShortToday := false
+    lastNYDom := nyDayOfMon
+
+// Reset flags on new session bar
+if isNewSessionBar
+    tradedLongToday  := false
+    tradedShortToday := false
+    lastNYDom := nyDayOfMon
+
+canLong  = inWindow and passLong  and not tradedLongToday
+canShort = inWindow and passShort and not tradedShortToday
+
+// ==========================
+// Orders and risk management
+// ==========================
+// Buffers
+bufferTicks  = minTicksBuf * syminfo.mintick
+bufferATR    = atr * atrMult
+bufferPoints = math.max(bufferTicks, bufferATR)
+
+// State for BE and time-stop
+var float longStopAtEntry  = na
+var float longTPAtEntry    = na
+var float shortStopAtEntry = na
+var float shortTPAtEntry   = na
+var int   longEntryTime    = na
+var int   shortEntryTime   = na
+
+enterLongCond  = canLong  and triggerLong  and withinDistLong  and not na(lastSwingLow)
+enterShortCond = canShort and triggerShort and withinDistShort and not na(lastSwingHigh)
+
+if enterLongCond and strategy.position_size <= 0
+    // Compute stop/TP from swing + buffer
+    longStop  = lastSwingLow - bufferPoints
+    // Approximate entry at close
+    longEntry = close
+    rDist     = math.max(longEntry - longStop, syminfo.mintick)
+    longTP    = longEntry + rMultiple * rDist
+
+    strategy.entry(id="L", direction=strategy.long, qty=qtyContracts)
+    strategy.exit(id="L-EXIT", from_entry="L", stop=longStop, limit=longTP)
+
+    tradedLongToday := true
+    longStopAtEntry := longStop
+    longTPAtEntry   := longTP
+    longEntryTime   := time
+
+if enterShortCond and strategy.position_size >= 0
+    shortStop  = lastSwingHigh + bufferPoints
+    shortEntry = close
+    rDist      = math.max(shortStop - shortEntry, syminfo.mintick)
+    shortTP    = shortEntry - rMultiple * rDist
+
+    strategy.entry(id="S", direction=strategy.short, qty=qtyContracts)
+    strategy.exit(id="S-EXIT", from_entry="S", stop=shortStop, limit=shortTP)
+
+    tradedShortToday := true
+    shortStopAtEntry := shortStop
+    shortTPAtEntry   := shortTP
+    shortEntryTime   := time
+
+// Move to BE at 1R
+if moveToBE and strategy.position_size > 0 and not na(longStopAtEntry)
+    entry = strategy.position_avg_price
+    rDist = entry - longStopAtEntry
+    if rDist > 0 and close - entry >= rDist
+        strategy.exit(id="L-EXIT", from_entry="L", stop=entry, limit=longTPAtEntry)
+
+if moveToBE and strategy.position_size < 0 and not na(shortStopAtEntry)
+    entry = strategy.position_avg_price
+    rDist = shortStopAtEntry - entry
+    if rDist > 0 and entry - close >= rDist
+        strategy.exit(id="S-EXIT", from_entry="S", stop=entry, limit=shortTPAtEntry)
+
+// Time-stop (minutes)
+if strategy.position_size > 0 and not na(longEntryTime)
+    minsInTrade = (time - longEntryTime) / 60000.0
+    if minsInTrade >= timeStopMin
+        strategy.close(id="L")
+        longEntryTime := na
+
+if strategy.position_size < 0 and not na(shortEntryTime)
+    minsInTrade = (time - shortEntryTime) / 60000.0
+    if minsInTrade >= timeStopMin
+        strategy.close(id="S")
+        shortEntryTime := na
+
+// Reset state on flat
+if strategy.position_size == 0
+    longStopAtEntry  := na
+    longTPAtEntry    := na
+    shortStopAtEntry := na
+    shortTPAtEntry   := na
+
+// ==========================
+// Plots & Debug
+// ==========================
+plot(avwap_asia,   color=color.new(color.teal,  0), title="AVWAP Asia")
+plot(avwap_london, color=color.new(color.blue,  0), title="AVWAP London")
+plot(avwap_pre,    color=color.new(color.gray,  0), title="AVWAP 8:00")
+plot(avwap_open,   color=color.new(color.orange,0), title="AVWAP 9:30")
+plot(avwap_ten,    color=color.new(color.purple,0), title="AVWAP 10:00")
+
+plotshape(showLabels and enterLongCond,  title="Long Signal",  style=shape.triangleup,   color=color.new(color.lime, 0), location=location.belowbar, size=size.tiny, text="L")
+plotshape(showLabels and enterShortCond, title="Short Signal", style=shape.triangledown, color=color.new(color.red,  0), location=location.abovebar, size=size.tiny, text="S")
+
+// Debug info
+if showDebug
+    label.new(bar_index, high, text=str.tostring(alignedCountLong) + "/" + str.tostring(alignedCountShort) + " aligned\n" + (passLong?"passLong":"") + (passShort?" passShort":""), style=label.style_label_down, color=color.new(color.silver, 60))


### PR DESCRIPTION
Implement a Pine Script strategy to backtest MNQ reversals at NY open using H1 bias and multiple AVWAP confluences.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9e362e7-1de3-42ed-8aa6-9b63288fa27e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9e362e7-1de3-42ed-8aa6-9b63288fa27e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

