### PR TITLE
Calculate 5m cvd on 1m

### DIFF
--- a/cvd_5m_on_1m.pine
+++ b/cvd_5m_on_1m.pine
@@ -9,19 +9,13 @@ f_delta() =>
          close < open ? -volume :
          0.0
 
-[delta_5m, htf_time] = request.security(
+delta_5m = request.security(
      syminfo.tickerid,
      "5",
-     [f_delta(), time],
+     f_delta(),
      lookahead = barmerge.lookahead_off,
      gaps = barmerge.gaps_off
  )
 
-htf_closed = ta.change(htf_time) != 0
-
-var float cvd = 0.0
-if htf_closed and not na(delta_5m)
-    cvd += delta_5m
-
-column_color = cvd >= 0 ? color.new(color.green, 0) : color.new(color.red, 0)
-plot(cvd, title = "HTF CVD (5m)", style = plot.style_columns, color = column_color, linewidth = 2)
+bar_color = delta_5m > 0 ? color.green : delta_5m < 0 ? color.red : color.gray
+plot(delta_5m, title = "HTF Delta (5m)", style = plot.style_columns, color = bar_color, linewidth = 2)

--- a/cvd_5m_on_1m.pine
+++ b/cvd_5m_on_1m.pine
@@ -5,12 +5,8 @@
 indicator("HTF CVD (5m on 1m)", "HTF CVD 5m", overlay = false, max_labels_count = 500)
 
 f_delta() =>
-    spread = math.max(high - low, syminfo.mintick)
-    body_length = math.abs(close - open)
-    percent_body_length = body_length / spread
-
-    close > open ? percent_body_length * volume :
-         close < open ? -(percent_body_length * volume) :
+    close > open ? volume :
+         close < open ? -volume :
          0.0
 
 [delta_5m, htf_time] = request.security(

--- a/cvd_5m_on_1m.pine
+++ b/cvd_5m_on_1m.pine
@@ -14,9 +14,10 @@ f_delta() =>
     percent_lower_wick = lower_wick / spread
     percent_body_length = body_length / spread
 
-    wick_mix = (percent_upper_wick + percent_lower_wick) / 2.0
-    buying_volume = close > open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
-    selling_volume = close < open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
+    half_wicks = (percent_upper_wick + percent_lower_wick) / 2.0
+    wick_only = half_wicks * volume
+    buying_volume = close > open ? (percent_body_length + half_wicks) * volume : wick_only
+    selling_volume = close < open ? (percent_body_length + half_wicks) * volume : wick_only
 
     buying_volume - selling_volume
 

--- a/cvd_5m_on_1m.pine
+++ b/cvd_5m_on_1m.pine
@@ -4,9 +4,7 @@
 //@version=6
 indicator("HTF CVD (5m on 1m)", "HTF CVD 5m", overlay = false, max_labels_count = 500)
 
-length = input.int(14, "Cumulation Length", minval = 1)
-
-f_cvd() =>
+f_delta() =>
     spread = math.max(high - low, syminfo.mintick)
     upper_wick = close > open ? high - close : high - open
     lower_wick = close > open ? open - low : close - low
@@ -17,37 +15,24 @@ f_cvd() =>
     percent_body_length = body_length / spread
 
     wick_mix = (percent_upper_wick + percent_lower_wick) / 2.0
-    buy_vol = close > open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
-    sell_vol = close < open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
+    buying_volume = close > open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
+    selling_volume = close < open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
 
-    buy_ema = ta.ema(buy_vol, length)
-    sell_ema = ta.ema(sell_vol, length)
-    volume_strength_wave = math.max(buy_ema, sell_ema)
-    wave = ta.ema(volume_strength_wave, length)
+    buying_volume - selling_volume
 
-    cvd = ta.cum(buy_vol - sell_vol)
-    [buy_ema, sell_ema, cvd, wave, time]
-
-[htf_buy_ema, htf_sell_ema, htf_cvd, htf_wave, htf_time] = request.security(
+[delta_5m, htf_time] = request.security(
      syminfo.tickerid,
      "5",
-     f_cvd(),
+     [f_delta(), time],
      lookahead = barmerge.lookahead_off,
      gaps = barmerge.gaps_off
  )
 
 htf_closed = ta.change(htf_time) != 0
 
-var float last_buy_ema = na
-var float last_sell_ema = na
-var float last_cvd = na
-var float last_wave = na
+var float cvd = 0.0
+if htf_closed and not na(delta_5m)
+    cvd += delta_5m
 
-if htf_closed
-    last_buy_ema := htf_buy_ema
-    last_sell_ema := htf_sell_ema
-    last_cvd := htf_cvd
-    last_wave := htf_wave
-
-column_color = last_cvd >= 0 ? color.new(color.green, 0) : color.new(color.red, 0)
-plot(last_cvd, title = "HTF CVD (5m)", style = plot.style_columns, color = column_color, linewidth = 2)
+column_color = cvd >= 0 ? color.new(color.green, 0) : color.new(color.red, 0)
+plot(cvd, title = "HTF CVD (5m)", style = plot.style_columns, color = column_color, linewidth = 2)

--- a/cvd_5m_on_1m.pine
+++ b/cvd_5m_on_1m.pine
@@ -1,0 +1,42 @@
+// This source code is subject to the terms of the Mozilla Public License 2.0 at https://mozilla.org/MPL/2.0/
+// © Ankit_1618 (original concept) | Modded for HTF CVD projection
+
+//@version=5
+indicator("HTF CVD (5m on 1m)", "HTF CVD 5m", overlay = false, max_labels_count = 500)
+
+f_delta() =>
+    spread = math.max(high - low, syminfo.mintick)
+    upper_wick = close > open ? high - close : high - open
+    lower_wick = close > open ? open - low : close - low
+    body_length = spread - (upper_wick + lower_wick)
+
+    percent_upper_wick = upper_wick / spread
+    percent_lower_wick = lower_wick / spread
+    percent_body_length = body_length / spread
+
+    wick_mix = (percent_upper_wick + percent_lower_wick) / 2.0
+    buying_volume = close > open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
+    selling_volume = close < open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
+
+    buying_volume - selling_volume
+
+delta_5m = request.security(
+     syminfo.tickerid,
+     "5",
+     f_delta(),
+     lookahead = barmerge.lookahead_on,
+     gaps = barmerge.gaps_off
+ )
+
+var float cvd_5m = 0.0
+new_htf_close = not na(delta_5m) and (na(delta_5m[1]) or delta_5m != delta_5m[1])
+cvd_5m := new_htf_close ? cvd_5m + delta_5m : cvd_5m
+
+zero_line = 0.0
+plot(zero_line, title = "Zero", color = color.new(color.gray, 85))
+plot(
+    cvd_5m,
+    title = "HTF CVD (5m)",
+    color = cvd_5m >= 0 ? color.green : color.red,
+    linewidth = 2
+)

--- a/cvd_5m_on_1m.pine
+++ b/cvd_5m_on_1m.pine
@@ -1,7 +1,7 @@
 // This source code is subject to the terms of the Mozilla Public License 2.0 at https://mozilla.org/MPL/2.0/
 // © Ankit_1618 (original concept) | Modded for HTF CVD projection
 
-//@version=5
+//@version=6
 indicator("HTF CVD (5m on 1m)", "HTF CVD 5m", overlay = false, max_labels_count = 500)
 
 f_delta() =>
@@ -34,9 +34,4 @@ cvd_5m := new_htf_close ? cvd_5m + delta_5m : cvd_5m
 
 zero_line = 0.0
 plot(zero_line, title = "Zero", color = color.new(color.gray, 85))
-plot(
-    cvd_5m,
-    title = "HTF CVD (5m)",
-    color = cvd_5m >= 0 ? color.green : color.red,
-    linewidth = 2
-)
+plot(cvd_5m, title = "HTF CVD (5m)", color = cvd_5m >= 0 ? color.green : color.red, linewidth = 2)

--- a/cvd_5m_on_1m.pine
+++ b/cvd_5m_on_1m.pine
@@ -4,34 +4,50 @@
 //@version=6
 indicator("HTF CVD (5m on 1m)", "HTF CVD 5m", overlay = false, max_labels_count = 500)
 
-f_delta() =>
+length = input.int(14, "Cumulation Length", minval = 1)
+
+f_cvd() =>
     spread = math.max(high - low, syminfo.mintick)
     upper_wick = close > open ? high - close : high - open
     lower_wick = close > open ? open - low : close - low
-    body_length = spread - (upper_wick + lower_wick)
+    body_length = math.max(spread - (upper_wick + lower_wick), 0.0)
 
     percent_upper_wick = upper_wick / spread
     percent_lower_wick = lower_wick / spread
     percent_body_length = body_length / spread
 
     wick_mix = (percent_upper_wick + percent_lower_wick) / 2.0
-    buying_volume = close > open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
-    selling_volume = close < open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
+    buy_vol = close > open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
+    sell_vol = close < open ? (percent_body_length + wick_mix) * volume : wick_mix * volume
 
-    buying_volume - selling_volume
+    buy_ema = ta.ema(buy_vol, length)
+    sell_ema = ta.ema(sell_vol, length)
+    volume_strength_wave = math.max(buy_ema, sell_ema)
+    wave = ta.ema(volume_strength_wave, length)
 
-delta_5m = request.security(
+    cvd = ta.cum(buy_vol - sell_vol)
+    [buy_ema, sell_ema, cvd, wave, time]
+
+[htf_buy_ema, htf_sell_ema, htf_cvd, htf_wave, htf_time] = request.security(
      syminfo.tickerid,
      "5",
-     f_delta(),
-     lookahead = barmerge.lookahead_on,
+     f_cvd(),
+     lookahead = barmerge.lookahead_off,
      gaps = barmerge.gaps_off
  )
 
-var float cvd_5m = 0.0
-new_htf_close = not na(delta_5m) and (na(delta_5m[1]) or delta_5m != delta_5m[1])
-cvd_5m := new_htf_close ? cvd_5m + delta_5m : cvd_5m
+htf_closed = ta.change(htf_time) != 0
 
-zero_line = 0.0
-plot(zero_line, title = "Zero", color = color.new(color.gray, 85))
-plot(cvd_5m, title = "HTF CVD (5m)", color = cvd_5m >= 0 ? color.green : color.red, linewidth = 2)
+var float last_buy_ema = na
+var float last_sell_ema = na
+var float last_cvd = na
+var float last_wave = na
+
+if htf_closed
+    last_buy_ema := htf_buy_ema
+    last_sell_ema := htf_sell_ema
+    last_cvd := htf_cvd
+    last_wave := htf_wave
+
+column_color = last_cvd >= 0 ? color.new(color.green, 0) : color.new(color.red, 0)
+plot(last_cvd, title = "HTF CVD (5m)", style = plot.style_columns, color = column_color, linewidth = 2)

--- a/cvd_5m_on_1m.pine
+++ b/cvd_5m_on_1m.pine
@@ -4,18 +4,23 @@
 //@version=6
 indicator("HTF CVD (5m on 1m)", "HTF CVD 5m", overlay = false, max_labels_count = 500)
 
+htf_res = input.timeframe("5", "HTF Resolution", confirm = true)
+len = input.int(1, "Delta Length", minval = 1)
+
 f_delta() =>
     close > open ? volume :
          close < open ? -volume :
          0.0
 
-delta_5m = request.security(
+delta_htf = request.security(
      syminfo.tickerid,
-     "5",
+     htf_res,
      f_delta(),
      lookahead = barmerge.lookahead_off,
      gaps = barmerge.gaps_off
  )
 
-bar_color = delta_5m > 0 ? color.green : delta_5m < 0 ? color.red : color.gray
-plot(delta_5m, title = "HTF Delta (5m)", style = plot.style_columns, color = bar_color, linewidth = 2)
+delta_smoothed = ta.ema(delta_htf, len)
+
+bar_color = delta_smoothed > 0 ? color.green : delta_smoothed < 0 ? color.red : color.gray
+plot(delta_smoothed, title = "HTF Delta", style = plot.style_columns, color = bar_color, linewidth = 2)

--- a/cvd_5m_on_1m.pine
+++ b/cvd_5m_on_1m.pine
@@ -6,20 +6,12 @@ indicator("HTF CVD (5m on 1m)", "HTF CVD 5m", overlay = false, max_labels_count 
 
 f_delta() =>
     spread = math.max(high - low, syminfo.mintick)
-    upper_wick = close > open ? high - close : high - open
-    lower_wick = close > open ? open - low : close - low
-    body_length = math.max(spread - (upper_wick + lower_wick), 0.0)
-
-    percent_upper_wick = upper_wick / spread
-    percent_lower_wick = lower_wick / spread
+    body_length = math.abs(close - open)
     percent_body_length = body_length / spread
 
-    half_wicks = (percent_upper_wick + percent_lower_wick) / 2.0
-    wick_only = half_wicks * volume
-    buying_volume = close > open ? (percent_body_length + half_wicks) * volume : wick_only
-    selling_volume = close < open ? (percent_body_length + half_wicks) * volume : wick_only
-
-    buying_volume - selling_volume
+    close > open ? percent_body_length * volume :
+         close < open ? -(percent_body_length * volume) :
+         0.0
 
 [delta_5m, htf_time] = request.security(
      syminfo.tickerid,


### PR DESCRIPTION
Implement a Pine Script indicator to display 5-minute Cumulative Volume Delta (CVD) on a 1-minute chart, updating only at 5-minute candle closes.

---
<a href="https://cursor.com/background-agent?bcId=bc-21f0a6e5-896e-4f6c-8f9c-e4066c38328c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21f0a6e5-896e-4f6c-8f9c-e4066c38328c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

