### PR TITLE
Fix SNIPER compile errors (ADX + sweep history calls)

### DIFF
--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -77,8 +77,17 @@ if blockStarted
 if blockEnded
     enteredThisBlock := false
 
-longSignal = inTradeBlock and not enteredThisBlock and newBull
-shortSignal = inTradeBlock and not enteredThisBlock and newBear
+var float blockOpenPrice = na
+if blockStarted
+    blockOpenPrice := open
+if blockEnded
+    blockOpenPrice := na
+
+allowLongByBlockOpen = not na(blockOpenPrice) and close > blockOpenPrice
+allowShortByBlockOpen = not na(blockOpenPrice) and close < blockOpenPrice
+
+longSignal = inTradeBlock and not enteredThisBlock and newBull and allowLongByBlockOpen
+shortSignal = inTradeBlock and not enteredThisBlock and newBear and allowShortByBlockOpen
 longStopFromSignal = low - stopPoints
 shortStopFromSignal = high + stopPoints
 
@@ -126,5 +135,6 @@ if lastBarOfBlock and strategy.position_size != 0
 
 bgcolor(bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na)
 plot(t3, title='T3', linewidth=2, color=t3Color)
+plot(blockOpenPrice, title='Block Open', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
 plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
 plotshape(newBear, title='Sell Signal', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -190,11 +190,23 @@ brokenMomentum = (bullAligned[1] and not bullAligned) or (bearAligned[1] and not
 inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
-sessionEndHour = int(str.tonumber(str.substring(tradeSession, 5, 7)))
-sessionEndMinute = int(str.tonumber(str.substring(tradeSession, 7, 9)))
+
+// Parse session end time defensively so custom session strings don't break runtime.
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ''
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ''
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidEnd = str.length(endTokenClean) >= 4
+endHourRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+sessionEndHour = (hasValidEnd and not na(endHourRaw)) ? int(endHourRaw) : 0
+sessionEndMinute = (hasValidEnd and not na(endMinuteRaw)) ? int(endMinuteRaw) : 0
 sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
 barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
-lastBarOfBlock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
+lastBarOfBlockByClock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
+lastBarOfBlock = hasValidEnd ? lastBarOfBlockByClock : blockEnded
 
 atrValue = ta.atr(atrLength)
 

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -198,15 +198,17 @@ lastBarOfBlock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
 
 atrValue = ta.atr(atrLength)
 
-// Take only the first fresh signal that appears inside each block.
+// Take only the first aligned condition that appears inside each block.
 var bool enteredThisBlock = false
 if blockStarted
     enteredThisBlock := false
 if blockEnded
     enteredThisBlock := false
 
-longSignal = inTradeBlock and not enteredThisBlock and newBull
-shortSignal = inTradeBlock and not enteredThisBlock and newBear
+bullEntryCondition = bullAligned and not bearAligned
+bearEntryCondition = bearAligned and not bullAligned
+longSignal = inTradeBlock and not enteredThisBlock and bullEntryCondition
+shortSignal = inTradeBlock and not enteredThisBlock and bearEntryCondition
 
 longStopFromSignal = stopMode == 'ATR' ? low - atrValue * atrMultiplier : low - stopPoints
 shortStopFromSignal = stopMode == 'ATR' ? high + atrValue * atrMultiplier : high + stopPoints

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -4,7 +4,7 @@
 // Derived from open-source works by DaviddTech (T3 & DI, CC BY-NC-SA 4.0)
 // and Ankit_1618 (Cumulative Volume Delta, MPL 2.0). Redistribution must honor originals.
 
-strategy('SZTrades Momentum Alignment Strategy', shorttitle='SZTStrat', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, initial_capital=10000)
+strategy('SZTrades Momentum Alignment Strategy', shorttitle='SZTStrat', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // T3 Filter Settings
@@ -191,22 +191,19 @@ inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
 
-sessionEndHour = int(str.tonumber(str.substring(tradeSession, 5, 7)))
-sessionEndMinute = int(str.tonumber(str.substring(tradeSession, 7, 9)))
-sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
-barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
-lastBarOfBlock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
-
 var float tradeBlockOpen = na
-if blockStarted
+if inTradeBlock and na(tradeBlockOpen)
     tradeBlockOpen := open
 if blockEnded
     tradeBlockOpen := na
 
 atrValue = ta.atr(atrLength)
 
-longSignal = inTradeBlock and not na(tradeBlockOpen) and newBull and close > tradeBlockOpen
-shortSignal = inTradeBlock and not na(tradeBlockOpen) and newBear and close < tradeBlockOpen
+entryBullTrigger = newBull or (blockStarted and bullAligned)
+entryBearTrigger = newBear or (blockStarted and bearAligned)
+
+longSignal = inTradeBlock and not na(tradeBlockOpen) and entryBullTrigger and close > tradeBlockOpen
+shortSignal = inTradeBlock and not na(tradeBlockOpen) and entryBearTrigger and close < tradeBlockOpen
 
 longStopFromSignal = stopMode == 'ATR' ? low - atrValue * atrMultiplier : low - stopPoints
 shortStopFromSignal = stopMode == 'ATR' ? high + atrValue * atrMultiplier : high + stopPoints
@@ -245,7 +242,7 @@ if strategy.position_size == 0
     activeLongStop := na
     activeShortStop := na
 
-if closeAtBlockEnd and lastBarOfBlock and strategy.position_size != 0
+if closeAtBlockEnd and blockEnded and strategy.position_size != 0
     strategy.close_all(comment='Block end close')
     pendingLongStop := na
     pendingShortStop := na

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -195,6 +195,12 @@ inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
 
+sessionEndHour = int(str.tonumber(str.substring(tradeSession, 5, 7)))
+sessionEndMinute = int(str.tonumber(str.substring(tradeSession, 7, 9)))
+sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
+lastBarOfBlock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
+
 var float tradeBlockOpen = na
 if blockStarted
     tradeBlockOpen := open
@@ -243,7 +249,7 @@ if strategy.position_size == 0
     activeLongStop := na
     activeShortStop := na
 
-if closeAtBlockEnd and blockEnded and strategy.position_size != 0
+if closeAtBlockEnd and lastBarOfBlock and strategy.position_size != 0
     strategy.close_all(comment='Block end close')
     pendingLongStop := na
     pendingShortStop := na

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -198,10 +198,15 @@ lastBarOfBlock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
 
 atrValue = ta.atr(atrLength)
 
-// Entry is allowed only on the first candle of the configured block
-// and only when a fresh buy/sell signal appears there.
-longSignal = blockStarted and newBull
-shortSignal = blockStarted and newBear
+// Take only the first fresh signal that appears inside each block.
+var bool enteredThisBlock = false
+if blockStarted
+    enteredThisBlock := false
+if blockEnded
+    enteredThisBlock := false
+
+longSignal = inTradeBlock and not enteredThisBlock and newBull
+shortSignal = inTradeBlock and not enteredThisBlock and newBear
 
 longStopFromSignal = stopMode == 'ATR' ? low - atrValue * atrMultiplier : low - stopPoints
 shortStopFromSignal = stopMode == 'ATR' ? high + atrValue * atrMultiplier : high + stopPoints
@@ -215,11 +220,13 @@ if longSignal and strategy.position_size <= 0
     pendingLongStop := longStopFromSignal
     pendingShortStop := na
     strategy.entry('Long', strategy.long, comment='Long aligned')
+    enteredThisBlock := true
 
 if shortSignal and strategy.position_size >= 0
     pendingShortStop := shortStopFromSignal
     pendingLongStop := na
     strategy.entry('Short', strategy.short, comment='Short aligned')
+    enteredThisBlock := true
 
 newLongPosition = strategy.position_size > 0 and strategy.position_size[1] <= 0
 newShortPosition = strategy.position_size < 0 and strategy.position_size[1] >= 0

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -198,17 +198,17 @@ lastBarOfBlock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
 
 atrValue = ta.atr(atrLength)
 
-// Take only the first aligned condition that appears inside each block.
+// Take only the first valid signal that appears inside each block.
 var bool enteredThisBlock = false
 if blockStarted
     enteredThisBlock := false
 if blockEnded
     enteredThisBlock := false
 
-bullEntryCondition = bullAligned and not bearAligned
-bearEntryCondition = bearAligned and not bullAligned
-longSignal = inTradeBlock and not enteredThisBlock and bullEntryCondition
-shortSignal = inTradeBlock and not enteredThisBlock and bearEntryCondition
+bullSignalInBlock = (inTradeBlock and newBull) or (blockStarted and bullAligned and not bearAligned)
+bearSignalInBlock = (inTradeBlock and newBear) or (blockStarted and bearAligned and not bullAligned)
+longSignal = not enteredThisBlock and bullSignalInBlock and not bearSignalInBlock
+shortSignal = not enteredThisBlock and bearSignalInBlock and not bullSignalInBlock
 
 longStopFromSignal = stopMode == 'ATR' ? low - atrValue * atrMultiplier : low - stopPoints
 shortStopFromSignal = stopMode == 'ATR' ? high + atrValue * atrMultiplier : high + stopPoints

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -1,0 +1,260 @@
+// @version=5
+// SZTrades Momentum Alignment Strategy
+// Converts the momentum alignment indicator into a backtestable strategy.
+// Derived from open-source works by DaviddTech (T3 & DI, CC BY-NC-SA 4.0)
+// and Ankit_1618 (Cumulative Volume Delta, MPL 2.0). Redistribution must honor originals.
+
+strategy('SZTrades Momentum Alignment Strategy', shorttitle='SZT Momentum Strat', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, initial_capital=10000)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T3 Filter Settings
+// ─────────────────────────────────────────────────────────────────────────────
+useT3 = input.bool(true, 'Use T3 Filter', group='T3 Filter')
+crossT3 = input.bool(true, 'Cross confirmation? - T3', group='T3 Filter')
+inverseT3 = input.bool(false, 'Inverse? - T3', group='T3 Filter')
+lengthT3 = input.int(5, 'Length - T3', minval=1, group='T3 Filter')
+factorT3 = input.float(0.7, 'Factor - T3', minval=0.0, maxval=1.0, group='T3 Filter')
+highlightMovementsT3 = input.bool(true, 'Highlight Movements? - T3', group='T3 Filter')
+srcT3 = input.source(close, 'Source - T3', group='T3 Filter')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CVD Filter Settings
+// ─────────────────────────────────────────────────────────────────────────────
+useCVD = input.bool(true, 'Use CVD Filter', group='CVD Filter')
+cumulationLength = input.int(14, 'Cumulation Length - CVD', minval=1, group='CVD Filter')
+cvdThreshold = input.float(0.0, 'Delta Threshold', minval=0.0, tooltip='Optional threshold to require stronger divergence', group='CVD Filter')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DI Filter Settings
+// ─────────────────────────────────────────────────────────────────────────────
+useDI = input.bool(true, 'Use Dorsey inertia Filter', group='DI Filter')
+crossDI = input.bool(true, 'Cross confirmation? - DI', group='DI Filter')
+inverseDI = input.bool(false, 'Inverse? - DI', group='DI Filter')
+middleLineLong = input.float(50.0, 'Middle Line Long - DI', group='DI Filter')
+middleLineShort = input.float(50.0, 'Middle Line Short - DI', group='DI Filter')
+stdevLengthDI = input.int(21, 'Std Dev Length - DI', minval=1, group='DI Filter')
+rvIDISmoothLength = input.int(14, 'rvIDI Smoothing Length - DI', minval=1, group='DI Filter')
+smoothLengthDI = input.int(14, 'Inertia Smoothing Length - DI', minval=1, group='DI Filter')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Strategy Rule Settings
+// ─────────────────────────────────────────────────────────────────────────────
+tradeSession = input.session('1000-1200', 'Trading Block (HHMM-HHMM)', group='Strategy Rules')
+sessionTimezone = input.string('Etc/GMT+4', 'Trading Block Timezone', options=['Etc/GMT+4', 'America/New_York', 'Etc/UTC'], group='Strategy Rules')
+only15m = input.bool(true, 'Only take entries on 15m chart', group='Strategy Rules')
+closeAtBlockEnd = input.bool(true, 'Close open trades when block ends', group='Strategy Rules')
+
+stopMode = input.string('Points', 'Stop Mode', options=['Points', 'ATR'], group='Risk Management')
+stopPoints = input.float(20.0, 'Stop Buffer (Points)', minval=0.0, step=0.1, group='Risk Management')
+atrLength = input.int(14, 'ATR Length', minval=1, group='Risk Management')
+atrMultiplier = input.float(1.5, 'ATR Multiplier', minval=0.1, step=0.1, group='Risk Management')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Display Settings
+// ─────────────────────────────────────────────────────────────────────────────
+showT3Line = input.bool(true, 'Plot T3 line', group='Display')
+showBullSignals = input.bool(true, 'Show Bull Signals', group='Display')
+showBearSignals = input.bool(true, 'Show Bear Signals', group='Display')
+showBreakSignals = input.bool(true, 'Show Break Signals', group='Display')
+backgroundTint = input.bool(true, 'Tint background on alignment', group='Display')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper functions
+// ─────────────────────────────────────────────────────────────────────────────
+gdT3(src, len) =>
+    ta.ema(src, len) * (1 + factorT3) - ta.ema(ta.ema(src, len), len) * factorT3
+
+rvIDIOriginal(src, stdevLen, smoothLen) =>
+    stdev = ta.stdev(src, stdevLen)
+    change = ta.change(src)
+    upSum = ta.ema(change >= 0 ? stdev : 0.0, smoothLen)
+    downSum = ta.ema(change >= 0 ? 0.0 : stdev, smoothLen)
+    denom = upSum + downSum
+    denom == 0.0 ? 50.0 : 100.0 * upSum / denom
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T3 core calculation & filter
+// ─────────────────────────────────────────────────────────────────────────────
+t3 = gdT3(gdT3(gdT3(srcT3, lengthT3), lengthT3), lengthT3)
+t3Direction = t3 > t3[1] ? 1 : t3 < t3[1] ? -1 : 0
+t3Color = highlightMovementsT3 ? (t3Direction > 0 ? color.green : color.red) : #6d1e7f
+
+basicLongT3 = t3Direction > 0 and close > t3
+basicShortT3 = t3Direction < 0 and close < t3
+longTriggerT3 = basicLongT3 and not nz(basicLongT3[1])
+shortTriggerT3 = basicShortT3 and not nz(basicShortT3[1])
+
+var bool t3StateLong = true
+var bool t3StateShort = true
+if barstate.isfirst
+    t3StateLong := not useT3 or basicLongT3
+    t3StateShort := not useT3 or basicShortT3
+else
+    if not useT3
+        t3StateLong := true
+        t3StateShort := true
+    else if crossT3
+        if longTriggerT3
+            t3StateLong := true
+            t3StateShort := false
+        else if shortTriggerT3
+            t3StateLong := false
+            t3StateShort := true
+        else
+            t3StateLong := nz(t3StateLong[1], false)
+            t3StateShort := nz(t3StateShort[1], false)
+    else
+        t3StateLong := basicLongT3
+        t3StateShort := basicShortT3
+
+if inverseT3
+    prevLong = t3StateLong
+    prevShort = t3StateShort
+    t3StateLong := prevShort
+    t3StateShort := prevLong
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CVD core calculation & filter
+// ─────────────────────────────────────────────────────────────────────────────
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpper = upperWick / spread
+percentLower = lowerWick / spread
+percentBody = bodyLength / spread
+halfWicks = (percentUpper + percentLower) / 2
+
+buyingVolume = close > open ? (percentBody + halfWicks) * volume : halfWicks * volume
+sellingVolume = close < open ? (percentBody + halfWicks) * volume : halfWicks * volume
+
+cumBuy = ta.ema(buyingVolume, cumulationLength)
+cumSell = ta.ema(sellingVolume, cumulationLength)
+cvdDelta = cumBuy - cumSell
+
+bullCVD = not useCVD ? true : cvdDelta > cvdThreshold
+bearCVD = not useCVD ? true : cvdDelta < -cvdThreshold
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DI core calculation & filter
+// ─────────────────────────────────────────────────────────────────────────────
+rvIDI = math.avg(rvIDIOriginal(high, stdevLengthDI, rvIDISmoothLength), rvIDIOriginal(low, stdevLengthDI, rvIDISmoothLength))
+inertiaDI = ta.linreg(rvIDI, smoothLengthDI, 0)
+
+baseLongDI = inertiaDI > middleLineLong
+baseShortDI = inertiaDI < middleLineShort
+longTriggerDI = baseLongDI and not nz(baseLongDI[1])
+shortTriggerDI = baseShortDI and not nz(baseShortDI[1])
+
+var bool diStateLong = true
+var bool diStateShort = true
+if barstate.isfirst
+    diStateLong := not useDI or baseLongDI
+    diStateShort := not useDI or baseShortDI
+else
+    if not useDI
+        diStateLong := true
+        diStateShort := true
+    else if crossDI
+        if longTriggerDI
+            diStateLong := true
+            diStateShort := false
+        else if shortTriggerDI
+            diStateLong := false
+            diStateShort := true
+        else
+            diStateLong := nz(diStateLong[1], false)
+            diStateShort := nz(diStateShort[1], false)
+    else
+        diStateLong := baseLongDI
+        diStateShort := baseShortDI
+
+if inverseDI
+    prevLongDI = diStateLong
+    prevShortDI = diStateShort
+    diStateLong := prevShortDI
+    diStateShort := prevLongDI
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alignment logic & signalling
+// ─────────────────────────────────────────────────────────────────────────────
+bullAligned = t3StateLong and bullCVD and diStateLong
+bearAligned = t3StateShort and bearCVD and diStateShort
+
+newBull = bullAligned and not bullAligned[1]
+newBear = bearAligned and not bearAligned[1]
+brokenMomentum = (bullAligned[1] and not bullAligned) or (bearAligned[1] and not bearAligned)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Trading block and execution logic
+// ─────────────────────────────────────────────────────────────────────────────
+is15m = timeframe.isminutes and timeframe.multiplier == 15
+canTrade = not only15m or is15m
+
+inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
+blockStarted = inTradeBlock and not inTradeBlock[1]
+blockEnded = not inTradeBlock and inTradeBlock[1]
+
+var float tradeBlockOpen = na
+if blockStarted
+    tradeBlockOpen := open
+if blockEnded
+    tradeBlockOpen := na
+
+atrValue = ta.atr(atrLength)
+
+longSignal = canTrade and inTradeBlock and not na(tradeBlockOpen) and newBull and close > tradeBlockOpen
+shortSignal = canTrade and inTradeBlock and not na(tradeBlockOpen) and newBear and close < tradeBlockOpen
+
+longStopFromSignal = stopMode == 'ATR' ? low - atrValue * atrMultiplier : low - stopPoints
+shortStopFromSignal = stopMode == 'ATR' ? high + atrValue * atrMultiplier : high + stopPoints
+
+var float pendingLongStop = na
+var float pendingShortStop = na
+var float activeLongStop = na
+var float activeShortStop = na
+
+if longSignal and strategy.position_size <= 0
+    pendingLongStop := longStopFromSignal
+    pendingShortStop := na
+    strategy.entry('Long', strategy.long, comment='Long aligned')
+
+if shortSignal and strategy.position_size >= 0
+    pendingShortStop := shortStopFromSignal
+    pendingLongStop := na
+    strategy.entry('Short', strategy.short, comment='Short aligned')
+
+newLongPosition = strategy.position_size > 0 and strategy.position_size[1] <= 0
+newShortPosition = strategy.position_size < 0 and strategy.position_size[1] >= 0
+
+if newLongPosition
+    activeLongStop := pendingLongStop
+    activeShortStop := na
+if newShortPosition
+    activeShortStop := pendingShortStop
+    activeLongStop := na
+
+if strategy.position_size > 0 and not na(activeLongStop)
+    strategy.exit('Long SL', 'Long', stop=activeLongStop)
+if strategy.position_size < 0 and not na(activeShortStop)
+    strategy.exit('Short SL', 'Short', stop=activeShortStop)
+
+if strategy.position_size == 0
+    activeLongStop := na
+    activeShortStop := na
+
+if closeAtBlockEnd and blockEnded and strategy.position_size != 0
+    strategy.close_all(comment='Block end close')
+    pendingLongStop := na
+    pendingShortStop := na
+
+bgcolor(backgroundTint ? (bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na) : na)
+
+plot(showT3Line and useT3 ? t3 : na, title='T3', linewidth=2, color=t3Color)
+plot(tradeBlockOpen, title='Block Open Price', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
+
+plotshape(showBullSignals and newBull, title='Bull Alignment', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
+plotshape(showBearSignals and newBear, title='Bear Alignment', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)
+plotshape(showBreakSignals and brokenMomentum, title='Momentum Break', location=location.top, style=shape.circle, color=color.new(color.orange, 0), size=size.tiny, text='X')
+
+plot(showBullSignals or showBearSignals ? (bullAligned ? 1 : bearAligned ? -1 : 0) : na, title='Alignment State', style=plot.style_columns, color=bullAligned ? color.green : bearAligned ? color.red : color.gray, transp=70)

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -1,120 +1,31 @@
 //@version=6
-// SZTrades Momentum Alignment Strategy
-// Converts the momentum alignment indicator into a backtestable strategy.
-// Derived from open-source works by DaviddTech (T3 & DI, CC BY-NC-SA 4.0)
-// and Ankit_1618 (Cumulative Volume Delta, MPL 2.0). Redistribution must honor originals.
+// SZTrades Momentum Alignment Strategy (T3 + CVD only)
+// DI filter removed intentionally for optimization workflow.
 
 strategy('SZTrades Momentum Alignment Strategy', shorttitle='SZTStrat', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100)
 
-// ─────────────────────────────────────────────────────────────────────────────
-// T3 Filter Settings
-// ─────────────────────────────────────────────────────────────────────────────
-useT3 = input.bool(true, 'Use T3 Filter', group='T3 Filter')
-crossT3 = input.bool(true, 'Cross confirmation? - T3', group='T3 Filter')
-inverseT3 = input.bool(false, 'Inverse? - T3', group='T3 Filter')
-lengthT3 = input.int(5, 'Length - T3', minval=1, group='T3 Filter')
-factorT3 = input.float(0.7, 'Factor - T3', minval=0.0, maxval=1.0, group='T3 Filter')
-highlightMovementsT3 = input.bool(true, 'Highlight Movements? - T3', group='T3 Filter')
-srcT3 = input.source(close, 'Source - T3', group='T3 Filter')
+// 5 optimization factors
+lengthT3 = input.int(5, 'T3 Length', minval=1, group='T3')
+factorT3 = input.float(0.7, 'T3 Factor', minval=0.0, maxval=1.0, group='T3')
+cumulationLength = input.int(14, 'CVD Cumulation Length', minval=1, group='CVD')
+cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, group='CVD')
+stopPoints = input.float(20.0, 'Stop Points', minval=0.0, step=0.1, group='Risk')
 
-// ─────────────────────────────────────────────────────────────────────────────
-// CVD Filter Settings
-// ─────────────────────────────────────────────────────────────────────────────
-useCVD = input.bool(true, 'Use CVD Filter', group='CVD Filter')
-cumulationLength = input.int(14, 'Cumulation Length - CVD', minval=1, group='CVD Filter')
-cvdThreshold = input.float(0.0, 'Delta Threshold', minval=0.0, tooltip='Optional threshold to require stronger divergence', group='CVD Filter')
+// Session controls (kept simple, no checkbox)
+tradeSession = input.session('1000-1330', 'Trading Block (HHMM-HHMM)', group='Session')
+sessionTimezone = 'Etc/GMT+4'
 
-// ─────────────────────────────────────────────────────────────────────────────
-// DI Filter Settings
-// ─────────────────────────────────────────────────────────────────────────────
-useDI = input.bool(true, 'Use Dorsey inertia Filter', group='DI Filter')
-crossDI = input.bool(true, 'Cross confirmation? - DI', group='DI Filter')
-inverseDI = input.bool(false, 'Inverse? - DI', group='DI Filter')
-middleLineLong = input.float(50.0, 'Middle Line Long - DI', group='DI Filter')
-middleLineShort = input.float(50.0, 'Middle Line Short - DI', group='DI Filter')
-stdevLengthDI = input.int(21, 'Std Dev Length - DI', minval=1, group='DI Filter')
-rvIDISmoothLength = input.int(14, 'rvIDI Smoothing Length - DI', minval=1, group='DI Filter')
-smoothLengthDI = input.int(14, 'Inertia Smoothing Length - DI', minval=1, group='DI Filter')
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Strategy Rule Settings
-// ─────────────────────────────────────────────────────────────────────────────
-tradeSession = input.session('1000-1200', 'Trading Block (HHMM-HHMM)', group='Strategy Rules')
-sessionTimezone = input.string('Etc/GMT+4', 'Trading Block Timezone', options=['Etc/GMT+4', 'America/New_York', 'Etc/UTC'], group='Strategy Rules')
-closeAtBlockEnd = input.bool(true, 'Close open trades when block ends', group='Strategy Rules')
-
-stopMode = input.string('Points', 'Stop Mode', options=['Points', 'ATR'], group='Risk Management')
-stopPoints = input.float(20.0, 'Stop Buffer (Points)', minval=0.0, step=0.1, group='Risk Management')
-atrLength = input.int(14, 'ATR Length', minval=1, group='Risk Management')
-atrMultiplier = input.float(1.5, 'ATR Multiplier', minval=0.1, step=0.1, group='Risk Management')
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Display Settings
-// ─────────────────────────────────────────────────────────────────────────────
-showT3Line = input.bool(true, 'Plot T3 line', group='Display')
-showBullSignals = input.bool(true, 'Show Bull Signals', group='Display')
-showBearSignals = input.bool(true, 'Show Bear Signals', group='Display')
-showBreakSignals = input.bool(true, 'Show Break Signals', group='Display')
-backgroundTint = input.bool(true, 'Tint background on alignment', group='Display')
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Helper functions
-// ─────────────────────────────────────────────────────────────────────────────
 gdT3(src, len) =>
     ta.ema(src, len) * (1 + factorT3) - ta.ema(ta.ema(src, len), len) * factorT3
 
-rvIDIOriginal(src, stdevLen, smoothLen) =>
-    stdev = ta.stdev(src, stdevLen)
-    change = ta.change(src)
-    upSum = ta.ema(change >= 0 ? stdev : 0.0, smoothLen)
-    downSum = ta.ema(change >= 0 ? 0.0 : stdev, smoothLen)
-    denom = upSum + downSum
-    denom == 0.0 ? 50.0 : 100.0 * upSum / denom
-
-// ─────────────────────────────────────────────────────────────────────────────
-// T3 core calculation & filter
-// ─────────────────────────────────────────────────────────────────────────────
-t3 = gdT3(gdT3(gdT3(srcT3, lengthT3), lengthT3), lengthT3)
+// T3 core
+t3 = gdT3(gdT3(gdT3(close, lengthT3), lengthT3), lengthT3)
 t3Direction = t3 > t3[1] ? 1 : t3 < t3[1] ? -1 : 0
-t3Color = highlightMovementsT3 ? (t3Direction > 0 ? color.green : color.red) : #6d1e7f
-
+t3Color = t3Direction > 0 ? color.green : color.red
 basicLongT3 = t3Direction > 0 and close > t3
 basicShortT3 = t3Direction < 0 and close < t3
-longTriggerT3 = bar_index > 0 and basicLongT3 and not basicLongT3[1]
-shortTriggerT3 = bar_index > 0 and basicShortT3 and not basicShortT3[1]
 
-var bool t3StateLong = true
-var bool t3StateShort = true
-if barstate.isfirst
-    t3StateLong := not useT3 or basicLongT3
-    t3StateShort := not useT3 or basicShortT3
-else
-    if not useT3
-        t3StateLong := true
-        t3StateShort := true
-    else if crossT3
-        if longTriggerT3
-            t3StateLong := true
-            t3StateShort := false
-        else if shortTriggerT3
-            t3StateLong := false
-            t3StateShort := true
-        else
-            t3StateLong := bar_index > 0 ? t3StateLong[1] : false
-            t3StateShort := bar_index > 0 ? t3StateShort[1] : false
-    else
-        t3StateLong := basicLongT3
-        t3StateShort := basicShortT3
-
-if inverseT3
-    prevLong = t3StateLong
-    prevShort = t3StateShort
-    t3StateLong := prevShort
-    t3StateShort := prevLong
-
-// ─────────────────────────────────────────────────────────────────────────────
-// CVD core calculation & filter
-// ─────────────────────────────────────────────────────────────────────────────
+// CVD core
 upperWick = close > open ? high - close : high - open
 lowerWick = close > open ? open - low : close - low
 spread = math.max(high - low, syminfo.mintick)
@@ -123,75 +34,26 @@ percentUpper = upperWick / spread
 percentLower = lowerWick / spread
 percentBody = bodyLength / spread
 halfWicks = (percentUpper + percentLower) / 2
-
 buyingVolume = close > open ? (percentBody + halfWicks) * volume : halfWicks * volume
 sellingVolume = close < open ? (percentBody + halfWicks) * volume : halfWicks * volume
-
 cumBuy = ta.ema(buyingVolume, cumulationLength)
 cumSell = ta.ema(sellingVolume, cumulationLength)
 cvdDelta = cumBuy - cumSell
+bullCVD = cvdDelta > cvdThreshold
+bearCVD = cvdDelta < -cvdThreshold
 
-bullCVD = not useCVD ? true : cvdDelta > cvdThreshold
-bearCVD = not useCVD ? true : cvdDelta < -cvdThreshold
-
-// ─────────────────────────────────────────────────────────────────────────────
-// DI core calculation & filter
-// ─────────────────────────────────────────────────────────────────────────────
-rvIDI = math.avg(rvIDIOriginal(high, stdevLengthDI, rvIDISmoothLength), rvIDIOriginal(low, stdevLengthDI, rvIDISmoothLength))
-inertiaDI = ta.linreg(rvIDI, smoothLengthDI, 0)
-
-baseLongDI = inertiaDI > middleLineLong
-baseShortDI = inertiaDI < middleLineShort
-longTriggerDI = bar_index > 0 and baseLongDI and not baseLongDI[1]
-shortTriggerDI = bar_index > 0 and baseShortDI and not baseShortDI[1]
-
-var bool diStateLong = true
-var bool diStateShort = true
-if barstate.isfirst
-    diStateLong := not useDI or baseLongDI
-    diStateShort := not useDI or baseShortDI
-else
-    if not useDI
-        diStateLong := true
-        diStateShort := true
-    else if crossDI
-        if longTriggerDI
-            diStateLong := true
-            diStateShort := false
-        else if shortTriggerDI
-            diStateLong := false
-            diStateShort := true
-        else
-            diStateLong := bar_index > 0 ? diStateLong[1] : false
-            diStateShort := bar_index > 0 ? diStateShort[1] : false
-    else
-        diStateLong := baseLongDI
-        diStateShort := baseShortDI
-
-if inverseDI
-    prevLongDI = diStateLong
-    prevShortDI = diStateShort
-    diStateLong := prevShortDI
-    diStateShort := prevLongDI
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Alignment logic & signalling
-// ─────────────────────────────────────────────────────────────────────────────
-bullAligned = t3StateLong and bullCVD and diStateLong
-bearAligned = t3StateShort and bearCVD and diStateShort
-
+// Buy/sell signals only when T3 and CVD are aligned.
+bullAligned = basicLongT3 and bullCVD
+bearAligned = basicShortT3 and bearCVD
 newBull = bullAligned and not bullAligned[1]
 newBear = bearAligned and not bearAligned[1]
-brokenMomentum = (bullAligned[1] and not bullAligned) or (bearAligned[1] and not bearAligned)
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Trading block and execution logic
-// ─────────────────────────────────────────────────────────────────────────────
+// Session state
 inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
 
-// Parse session end time defensively so custom session strings don't break runtime.
+// Parse session end time defensively.
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
 sessionRanges = str.split(sessionCore, ",")
 lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ''
@@ -208,22 +70,17 @@ barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close
 lastBarOfBlockByClock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
 lastBarOfBlock = hasValidEnd ? lastBarOfBlockByClock : blockEnded
 
-atrValue = ta.atr(atrLength)
-
-// Take only the first fresh buy/sell signal that appears inside each block.
+// Only first fresh signal inside each block. No re-entry until close.
 var bool enteredThisBlock = false
 if blockStarted
     enteredThisBlock := false
 if blockEnded
     enteredThisBlock := false
 
-bullSignalInBlock = inTradeBlock and newBull
-bearSignalInBlock = inTradeBlock and newBear
-longSignal = not enteredThisBlock and bullSignalInBlock and not bearSignalInBlock
-shortSignal = not enteredThisBlock and bearSignalInBlock and not bullSignalInBlock
-
-longStopFromSignal = stopMode == 'ATR' ? low - atrValue * atrMultiplier : low - stopPoints
-shortStopFromSignal = stopMode == 'ATR' ? high + atrValue * atrMultiplier : high + stopPoints
+longSignal = inTradeBlock and not enteredThisBlock and newBull
+shortSignal = inTradeBlock and not enteredThisBlock and newBear
+longStopFromSignal = low - stopPoints
+shortStopFromSignal = high + stopPoints
 
 var float pendingLongStop = na
 var float pendingShortStop = na
@@ -233,13 +90,13 @@ var float activeShortStop = na
 if longSignal and strategy.position_size == 0
     pendingLongStop := longStopFromSignal
     pendingShortStop := na
-    strategy.entry('Long', strategy.long, comment='Long aligned')
+    strategy.entry('Long', strategy.long, comment='Buy signal')
     enteredThisBlock := true
 
 if shortSignal and strategy.position_size == 0
     pendingShortStop := shortStopFromSignal
     pendingLongStop := na
-    strategy.entry('Short', strategy.short, comment='Short aligned')
+    strategy.entry('Short', strategy.short, comment='Sell signal')
     enteredThisBlock := true
 
 newLongPosition = strategy.position_size > 0 and strategy.position_size[1] <= 0
@@ -261,18 +118,13 @@ if strategy.position_size == 0
     activeLongStop := na
     activeShortStop := na
 
-if closeAtBlockEnd and lastBarOfBlock and strategy.position_size != 0
+// Forced close at block end, always on.
+if lastBarOfBlock and strategy.position_size != 0
     strategy.close_all(comment='Block end close', immediately=true)
     pendingLongStop := na
     pendingShortStop := na
 
-bgcolor(backgroundTint ? (bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na) : na)
-
-plot(showT3Line and useT3 ? t3 : na, title='T3', linewidth=2, color=t3Color)
-
-plotshape(showBullSignals and newBull, title='Bull Alignment', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
-plotshape(showBearSignals and newBear, title='Bear Alignment', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)
-plotshape(showBreakSignals and brokenMomentum, title='Momentum Break', location=location.top, style=shape.circle, color=color.new(color.orange, 0), size=size.tiny, text='X')
-
-alignmentColor = bullAligned ? color.new(color.green, 70) : bearAligned ? color.new(color.red, 70) : color.new(color.gray, 70)
-plot(showBullSignals or showBearSignals ? (bullAligned ? 1 : bearAligned ? -1 : 0) : na, title='Alignment State', style=plot.style_columns, color=alignmentColor)
+bgcolor(bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na)
+plot(t3, title='T3', linewidth=2, color=t3Color)
+plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
+plotshape(newBear, title='Sell Signal', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -81,8 +81,8 @@ t3Color = highlightMovementsT3 ? (t3Direction > 0 ? color.green : color.red) : #
 
 basicLongT3 = t3Direction > 0 and close > t3
 basicShortT3 = t3Direction < 0 and close < t3
-longTriggerT3 = basicLongT3 and not nz(basicLongT3[1])
-shortTriggerT3 = basicShortT3 and not nz(basicShortT3[1])
+longTriggerT3 = basicLongT3 and not (na(basicLongT3[1]) ? false : basicLongT3[1])
+shortTriggerT3 = basicShortT3 and not (na(basicShortT3[1]) ? false : basicShortT3[1])
 
 var bool t3StateLong = true
 var bool t3StateShort = true
@@ -101,8 +101,8 @@ else
             t3StateLong := false
             t3StateShort := true
         else
-            t3StateLong := nz(t3StateLong[1], false)
-            t3StateShort := nz(t3StateShort[1], false)
+            t3StateLong := na(t3StateLong[1]) ? false : t3StateLong[1]
+            t3StateShort := na(t3StateShort[1]) ? false : t3StateShort[1]
     else
         t3StateLong := basicLongT3
         t3StateShort := basicShortT3
@@ -143,8 +143,8 @@ inertiaDI = ta.linreg(rvIDI, smoothLengthDI, 0)
 
 baseLongDI = inertiaDI > middleLineLong
 baseShortDI = inertiaDI < middleLineShort
-longTriggerDI = baseLongDI and not nz(baseLongDI[1])
-shortTriggerDI = baseShortDI and not nz(baseShortDI[1])
+longTriggerDI = baseLongDI and not (na(baseLongDI[1]) ? false : baseLongDI[1])
+shortTriggerDI = baseShortDI and not (na(baseShortDI[1]) ? false : baseShortDI[1])
 
 var bool diStateLong = true
 var bool diStateShort = true
@@ -163,8 +163,8 @@ else
             diStateLong := false
             diStateShort := true
         else
-            diStateLong := nz(diStateLong[1], false)
-            diStateShort := nz(diStateShort[1], false)
+            diStateLong := na(diStateLong[1]) ? false : diStateLong[1]
+            diStateShort := na(diStateShort[1]) ? false : diStateShort[1]
     else
         diStateLong := baseLongDI
         diStateShort := baseShortDI

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -209,11 +209,8 @@ if blockEnded
 
 atrValue = ta.atr(atrLength)
 
-entryBullTrigger = newBull or (blockStarted and bullAligned)
-entryBearTrigger = newBear or (blockStarted and bearAligned)
-
-longSignal = inTradeBlock and entryWindowOpen and not na(tradeBlockOpen) and entryBullTrigger and close > tradeBlockOpen
-shortSignal = inTradeBlock and entryWindowOpen and not na(tradeBlockOpen) and entryBearTrigger and close < tradeBlockOpen
+longSignal = inTradeBlock and entryWindowOpen and not na(tradeBlockOpen) and newBull and close > tradeBlockOpen
+shortSignal = inTradeBlock and entryWindowOpen and not na(tradeBlockOpen) and newBear and close < tradeBlockOpen
 
 longStopFromSignal = stopMode == 'ATR' ? low - atrValue * atrMultiplier : low - stopPoints
 shortStopFromSignal = stopMode == 'ATR' ? high + atrValue * atrMultiplier : high + stopPoints

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -1,10 +1,10 @@
-// @version=5
+//@version=6
 // SZTrades Momentum Alignment Strategy
 // Converts the momentum alignment indicator into a backtestable strategy.
 // Derived from open-source works by DaviddTech (T3 & DI, CC BY-NC-SA 4.0)
 // and Ankit_1618 (Cumulative Volume Delta, MPL 2.0). Redistribution must honor originals.
 
-strategy('SZTrades Momentum Alignment Strategy', shorttitle='SZT Momentum Strat', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, initial_capital=10000)
+strategy('SZTrades Momentum Alignment Strategy', shorttitle='SZTStrat', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, initial_capital=10000)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // T3 Filter Settings
@@ -263,4 +263,5 @@ plotshape(showBullSignals and newBull, title='Bull Alignment', location=location
 plotshape(showBearSignals and newBear, title='Bear Alignment', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)
 plotshape(showBreakSignals and brokenMomentum, title='Momentum Break', location=location.top, style=shape.circle, color=color.new(color.orange, 0), size=size.tiny, text='X')
 
-plot(showBullSignals or showBearSignals ? (bullAligned ? 1 : bearAligned ? -1 : 0) : na, title='Alignment State', style=plot.style_columns, color=bullAligned ? color.green : bearAligned ? color.red : color.gray, transp=70)
+alignmentColor = bullAligned ? color.new(color.green, 70) : bearAligned ? color.new(color.red, 70) : color.new(color.gray, 70)
+plot(showBullSignals or showBearSignals ? (bullAligned ? 1 : bearAligned ? -1 : 0) : na, title='Alignment State', style=plot.style_columns, color=alignmentColor)

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -42,6 +42,9 @@ smoothLengthDI = input.int(14, 'Inertia Smoothing Length - DI', minval=1, group=
 tradeSession = input.session('1000-1200', 'Trading Block (HHMM-HHMM)', group='Strategy Rules')
 sessionTimezone = input.string('Etc/GMT+4', 'Trading Block Timezone', options=['Etc/GMT+4', 'America/New_York', 'Etc/UTC'], group='Strategy Rules')
 closeAtBlockEnd = input.bool(true, 'Close open trades when block ends', group='Strategy Rules')
+useEntryCutoff = input.bool(true, 'Use entry cutoff time', group='Strategy Rules')
+entryCutoffHour = input.int(11, 'Entry Cutoff Hour', minval=0, maxval=23, group='Strategy Rules')
+entryCutoffMinute = input.int(45, 'Entry Cutoff Minute', minval=0, maxval=59, group='Strategy Rules')
 
 stopMode = input.string('Points', 'Stop Mode', options=['Points', 'ATR'], group='Risk Management')
 stopPoints = input.float(20.0, 'Stop Buffer (Points)', minval=0.0, step=0.1, group='Risk Management')
@@ -195,6 +198,8 @@ sessionEndMinute = int(str.tonumber(str.substring(tradeSession, 7, 9)))
 sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
 barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
 lastBarOfBlock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
+entryCutoffMinuteOfDay = entryCutoffHour * 60 + entryCutoffMinute
+entryWindowOpen = not useEntryCutoff or barCloseMinuteOfDay <= entryCutoffMinuteOfDay
 
 var float tradeBlockOpen = na
 if inTradeBlock and na(tradeBlockOpen)
@@ -207,8 +212,8 @@ atrValue = ta.atr(atrLength)
 entryBullTrigger = newBull or (blockStarted and bullAligned)
 entryBearTrigger = newBear or (blockStarted and bearAligned)
 
-longSignal = inTradeBlock and not na(tradeBlockOpen) and entryBullTrigger and close > tradeBlockOpen
-shortSignal = inTradeBlock and not na(tradeBlockOpen) and entryBearTrigger and close < tradeBlockOpen
+longSignal = inTradeBlock and entryWindowOpen and not na(tradeBlockOpen) and entryBullTrigger and close > tradeBlockOpen
+shortSignal = inTradeBlock and entryWindowOpen and not na(tradeBlockOpen) and entryBearTrigger and close < tradeBlockOpen
 
 longStopFromSignal = stopMode == 'ATR' ? low - atrValue * atrMultiplier : low - stopPoints
 shortStopFromSignal = stopMode == 'ATR' ? high + atrValue * atrMultiplier : high + stopPoints

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -198,15 +198,15 @@ lastBarOfBlock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
 
 atrValue = ta.atr(atrLength)
 
-// Take only the first valid signal that appears inside each block.
+// Take only the first fresh buy/sell signal that appears inside each block.
 var bool enteredThisBlock = false
 if blockStarted
     enteredThisBlock := false
 if blockEnded
     enteredThisBlock := false
 
-bullSignalInBlock = (inTradeBlock and newBull) or (blockStarted and bullAligned and not bearAligned)
-bearSignalInBlock = (inTradeBlock and newBear) or (blockStarted and bearAligned and not bullAligned)
+bullSignalInBlock = inTradeBlock and newBull
+bearSignalInBlock = inTradeBlock and newBear
 longSignal = not enteredThisBlock and bullSignalInBlock and not bearSignalInBlock
 shortSignal = not enteredThisBlock and bearSignalInBlock and not bullSignalInBlock
 

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -190,6 +190,11 @@ brokenMomentum = (bullAligned[1] and not bullAligned) or (bearAligned[1] and not
 inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
+sessionEndHour = int(str.tonumber(str.substring(tradeSession, 5, 7)))
+sessionEndMinute = int(str.tonumber(str.substring(tradeSession, 7, 9)))
+sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
+lastBarOfBlock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
 
 var float tradeBlockOpen = na
 if inTradeBlock and na(tradeBlockOpen)
@@ -242,8 +247,8 @@ if strategy.position_size == 0
     activeLongStop := na
     activeShortStop := na
 
-if closeAtBlockEnd and blockEnded and strategy.position_size != 0
-    strategy.close_all(comment='Block end close')
+if closeAtBlockEnd and lastBarOfBlock and strategy.position_size != 0
+    strategy.close_all(comment='Block end close', immediately=true)
     pendingLongStop := na
     pendingShortStop := na
 

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -41,7 +41,6 @@ smoothLengthDI = input.int(14, 'Inertia Smoothing Length - DI', minval=1, group=
 // ─────────────────────────────────────────────────────────────────────────────
 tradeSession = input.session('1000-1200', 'Trading Block (HHMM-HHMM)', group='Strategy Rules')
 sessionTimezone = input.string('Etc/GMT+4', 'Trading Block Timezone', options=['Etc/GMT+4', 'America/New_York', 'Etc/UTC'], group='Strategy Rules')
-only15m = input.bool(true, 'Only take entries on 15m chart', group='Strategy Rules')
 closeAtBlockEnd = input.bool(true, 'Close open trades when block ends', group='Strategy Rules')
 
 stopMode = input.string('Points', 'Stop Mode', options=['Points', 'ATR'], group='Risk Management')
@@ -188,9 +187,6 @@ brokenMomentum = (bullAligned[1] and not bullAligned) or (bearAligned[1] and not
 // ─────────────────────────────────────────────────────────────────────────────
 // Trading block and execution logic
 // ─────────────────────────────────────────────────────────────────────────────
-is15m = timeframe.isminutes and timeframe.multiplier == 15
-canTrade = not only15m or is15m
-
 inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
@@ -209,8 +205,8 @@ if blockEnded
 
 atrValue = ta.atr(atrLength)
 
-longSignal = canTrade and inTradeBlock and not na(tradeBlockOpen) and newBull and close > tradeBlockOpen
-shortSignal = canTrade and inTradeBlock and not na(tradeBlockOpen) and newBear and close < tradeBlockOpen
+longSignal = inTradeBlock and not na(tradeBlockOpen) and newBull and close > tradeBlockOpen
+shortSignal = inTradeBlock and not na(tradeBlockOpen) and newBear and close < tradeBlockOpen
 
 longStopFromSignal = stopMode == 'ATR' ? low - atrValue * atrMultiplier : low - stopPoints
 shortStopFromSignal = stopMode == 'ATR' ? high + atrValue * atrMultiplier : high + stopPoints

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -81,8 +81,8 @@ t3Color = highlightMovementsT3 ? (t3Direction > 0 ? color.green : color.red) : #
 
 basicLongT3 = t3Direction > 0 and close > t3
 basicShortT3 = t3Direction < 0 and close < t3
-longTriggerT3 = basicLongT3 and not (na(basicLongT3[1]) ? false : basicLongT3[1])
-shortTriggerT3 = basicShortT3 and not (na(basicShortT3[1]) ? false : basicShortT3[1])
+longTriggerT3 = bar_index > 0 and basicLongT3 and not basicLongT3[1]
+shortTriggerT3 = bar_index > 0 and basicShortT3 and not basicShortT3[1]
 
 var bool t3StateLong = true
 var bool t3StateShort = true
@@ -101,8 +101,8 @@ else
             t3StateLong := false
             t3StateShort := true
         else
-            t3StateLong := na(t3StateLong[1]) ? false : t3StateLong[1]
-            t3StateShort := na(t3StateShort[1]) ? false : t3StateShort[1]
+            t3StateLong := bar_index > 0 ? t3StateLong[1] : false
+            t3StateShort := bar_index > 0 ? t3StateShort[1] : false
     else
         t3StateLong := basicLongT3
         t3StateShort := basicShortT3
@@ -143,8 +143,8 @@ inertiaDI = ta.linreg(rvIDI, smoothLengthDI, 0)
 
 baseLongDI = inertiaDI > middleLineLong
 baseShortDI = inertiaDI < middleLineShort
-longTriggerDI = baseLongDI and not (na(baseLongDI[1]) ? false : baseLongDI[1])
-shortTriggerDI = baseShortDI and not (na(baseShortDI[1]) ? false : baseShortDI[1])
+longTriggerDI = bar_index > 0 and baseLongDI and not baseLongDI[1]
+shortTriggerDI = bar_index > 0 and baseShortDI and not baseShortDI[1]
 
 var bool diStateLong = true
 var bool diStateShort = true
@@ -163,8 +163,8 @@ else
             diStateLong := false
             diStateShort := true
         else
-            diStateLong := na(diStateLong[1]) ? false : diStateLong[1]
-            diStateShort := na(diStateShort[1]) ? false : diStateShort[1]
+            diStateLong := bar_index > 0 ? diStateLong[1] : false
+            diStateShort := bar_index > 0 ? diStateShort[1] : false
     else
         diStateLong := baseLongDI
         diStateShort := baseShortDI

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -216,13 +216,13 @@ var float pendingShortStop = na
 var float activeLongStop = na
 var float activeShortStop = na
 
-if longSignal and strategy.position_size <= 0
+if longSignal and strategy.position_size == 0
     pendingLongStop := longStopFromSignal
     pendingShortStop := na
     strategy.entry('Long', strategy.long, comment='Long aligned')
     enteredThisBlock := true
 
-if shortSignal and strategy.position_size >= 0
+if shortSignal and strategy.position_size == 0
     pendingShortStop := shortStopFromSignal
     pendingLongStop := na
     strategy.entry('Short', strategy.short, comment='Short aligned')

--- a/SZTrades_Momentum_Strategy.pine
+++ b/SZTrades_Momentum_Strategy.pine
@@ -42,9 +42,6 @@ smoothLengthDI = input.int(14, 'Inertia Smoothing Length - DI', minval=1, group=
 tradeSession = input.session('1000-1200', 'Trading Block (HHMM-HHMM)', group='Strategy Rules')
 sessionTimezone = input.string('Etc/GMT+4', 'Trading Block Timezone', options=['Etc/GMT+4', 'America/New_York', 'Etc/UTC'], group='Strategy Rules')
 closeAtBlockEnd = input.bool(true, 'Close open trades when block ends', group='Strategy Rules')
-useEntryCutoff = input.bool(true, 'Use entry cutoff time', group='Strategy Rules')
-entryCutoffHour = input.int(11, 'Entry Cutoff Hour', minval=0, maxval=23, group='Strategy Rules')
-entryCutoffMinute = input.int(45, 'Entry Cutoff Minute', minval=0, maxval=59, group='Strategy Rules')
 
 stopMode = input.string('Points', 'Stop Mode', options=['Points', 'ATR'], group='Risk Management')
 stopPoints = input.float(20.0, 'Stop Buffer (Points)', minval=0.0, step=0.1, group='Risk Management')
@@ -198,19 +195,13 @@ sessionEndMinute = int(str.tonumber(str.substring(tradeSession, 7, 9)))
 sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
 barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
 lastBarOfBlock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
-entryCutoffMinuteOfDay = entryCutoffHour * 60 + entryCutoffMinute
-entryWindowOpen = not useEntryCutoff or barCloseMinuteOfDay <= entryCutoffMinuteOfDay
-
-var float tradeBlockOpen = na
-if inTradeBlock and na(tradeBlockOpen)
-    tradeBlockOpen := open
-if blockEnded
-    tradeBlockOpen := na
 
 atrValue = ta.atr(atrLength)
 
-longSignal = inTradeBlock and entryWindowOpen and not na(tradeBlockOpen) and newBull and close > tradeBlockOpen
-shortSignal = inTradeBlock and entryWindowOpen and not na(tradeBlockOpen) and newBear and close < tradeBlockOpen
+// Entry is allowed only on the first candle of the configured block
+// and only when a fresh buy/sell signal appears there.
+longSignal = blockStarted and newBull
+shortSignal = blockStarted and newBear
 
 longStopFromSignal = stopMode == 'ATR' ? low - atrValue * atrMultiplier : low - stopPoints
 shortStopFromSignal = stopMode == 'ATR' ? high + atrValue * atrMultiplier : high + stopPoints
@@ -257,7 +248,6 @@ if closeAtBlockEnd and lastBarOfBlock and strategy.position_size != 0
 bgcolor(backgroundTint ? (bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na) : na)
 
 plot(showT3Line and useT3 ? t3 : na, title='T3', linewidth=2, color=t3Color)
-plot(tradeBlockOpen, title='Block Open Price', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
 
 plotshape(showBullSignals and newBull, title='Bull Alignment', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
 plotshape(showBearSignals and newBear, title='Bear Alignment', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy_1_2.pine
+++ b/SZTrades_Momentum_Strategy_1_2.pine
@@ -1,0 +1,149 @@
+//@version=6
+// SZTrades Momentum Alignment Strategy v1.2 (T3 + CVD only)
+// Adds a daily open filter anchored at 18:00 (UTC-4).
+
+strategy('SZTrades Momentum Alignment Strategy v1.2', shorttitle='SZT1.2', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100)
+
+// 5 optimization factors
+lengthT3 = input.int(5, 'T3 Length', minval=1, group='T3')
+factorT3 = input.float(0.7, 'T3 Factor', minval=0.0, maxval=1.0, group='T3')
+cumulationLength = input.int(14, 'CVD Cumulation Length', minval=1, group='CVD')
+cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, group='CVD')
+stopPoints = input.float(20.0, 'Stop Points', minval=0.0, step=0.1, group='Risk')
+
+// Session controls (kept simple, no checkbox)
+tradeSession = input.session('1000-1330', 'Trading Block (HHMM-HHMM)', group='Session')
+sessionTimezone = 'Etc/GMT+4'
+
+gdT3(src, len) =>
+    ta.ema(src, len) * (1 + factorT3) - ta.ema(ta.ema(src, len), len) * factorT3
+
+// T3 core
+t3 = gdT3(gdT3(gdT3(close, lengthT3), lengthT3), lengthT3)
+t3Direction = t3 > t3[1] ? 1 : t3 < t3[1] ? -1 : 0
+t3Color = t3Direction > 0 ? color.green : color.red
+basicLongT3 = t3Direction > 0 and close > t3
+basicShortT3 = t3Direction < 0 and close < t3
+
+// CVD core
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpper = upperWick / spread
+percentLower = lowerWick / spread
+percentBody = bodyLength / spread
+halfWicks = (percentUpper + percentLower) / 2
+buyingVolume = close > open ? (percentBody + halfWicks) * volume : halfWicks * volume
+sellingVolume = close < open ? (percentBody + halfWicks) * volume : halfWicks * volume
+cumBuy = ta.ema(buyingVolume, cumulationLength)
+cumSell = ta.ema(sellingVolume, cumulationLength)
+cvdDelta = cumBuy - cumSell
+bullCVD = cvdDelta > cvdThreshold
+bearCVD = cvdDelta < -cvdThreshold
+
+// Buy/sell signals only when T3 and CVD are aligned.
+bullAligned = basicLongT3 and bullCVD
+bearAligned = basicShortT3 and bearCVD
+newBull = bullAligned and not bullAligned[1]
+newBear = bearAligned and not bearAligned[1]
+
+// Session state
+inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
+blockStarted = inTradeBlock and not inTradeBlock[1]
+blockEnded = not inTradeBlock and inTradeBlock[1]
+
+// Parse session end time defensively.
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ''
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ''
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidEnd = str.length(endTokenClean) >= 4
+endHourRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+sessionEndHour = (hasValidEnd and not na(endHourRaw)) ? int(endHourRaw) : 0
+sessionEndMinute = (hasValidEnd and not na(endMinuteRaw)) ? int(endMinuteRaw) : 0
+sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
+lastBarOfBlockByClock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
+lastBarOfBlock = hasValidEnd ? lastBarOfBlockByClock : blockEnded
+
+// Daily open anchor at 18:00 in UTC-4.
+isDailyAnchorBar = hour(time, sessionTimezone) == 18 and minute(time, sessionTimezone) == 0
+var float dailyOpen1800 = na
+if isDailyAnchorBar
+    dailyOpen1800 := open
+
+// Only first fresh signal inside each block. No re-entry until close.
+var bool enteredThisBlock = false
+if blockStarted
+    enteredThisBlock := false
+if blockEnded
+    enteredThisBlock := false
+
+var float blockOpenPrice = na
+if blockStarted
+    blockOpenPrice := open
+if blockEnded
+    blockOpenPrice := na
+
+allowLongByBlockOpen = not na(blockOpenPrice) and close > blockOpenPrice
+allowShortByBlockOpen = not na(blockOpenPrice) and close < blockOpenPrice
+allowLongByDailyOpen = not na(dailyOpen1800) and close > dailyOpen1800
+allowShortByDailyOpen = not na(dailyOpen1800) and close < dailyOpen1800
+
+longSignal = inTradeBlock and not enteredThisBlock and newBull and allowLongByBlockOpen and allowLongByDailyOpen
+shortSignal = inTradeBlock and not enteredThisBlock and newBear and allowShortByBlockOpen and allowShortByDailyOpen
+longStopFromSignal = low - stopPoints
+shortStopFromSignal = high + stopPoints
+
+var float pendingLongStop = na
+var float pendingShortStop = na
+var float activeLongStop = na
+var float activeShortStop = na
+
+if longSignal and strategy.position_size == 0
+    pendingLongStop := longStopFromSignal
+    pendingShortStop := na
+    strategy.entry('Long', strategy.long, comment='Buy signal')
+    enteredThisBlock := true
+
+if shortSignal and strategy.position_size == 0
+    pendingShortStop := shortStopFromSignal
+    pendingLongStop := na
+    strategy.entry('Short', strategy.short, comment='Sell signal')
+    enteredThisBlock := true
+
+newLongPosition = strategy.position_size > 0 and strategy.position_size[1] <= 0
+newShortPosition = strategy.position_size < 0 and strategy.position_size[1] >= 0
+
+if newLongPosition
+    activeLongStop := pendingLongStop
+    activeShortStop := na
+if newShortPosition
+    activeShortStop := pendingShortStop
+    activeLongStop := na
+
+if strategy.position_size > 0 and not na(activeLongStop)
+    strategy.exit('Long SL', 'Long', stop=activeLongStop)
+if strategy.position_size < 0 and not na(activeShortStop)
+    strategy.exit('Short SL', 'Short', stop=activeShortStop)
+
+if strategy.position_size == 0
+    activeLongStop := na
+    activeShortStop := na
+
+// Forced close at block end, always on.
+if lastBarOfBlock and strategy.position_size != 0
+    strategy.close_all(comment='Block end close', immediately=true)
+    pendingLongStop := na
+    pendingShortStop := na
+
+bgcolor(bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na)
+plot(t3, title='T3', linewidth=2, color=t3Color)
+plot(blockOpenPrice, title='Block Open', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
+plot(dailyOpen1800, title='Daily Open 18:00', color=color.new(color.aqua, 0), linewidth=2, style=plot.style_linebr)
+plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
+plotshape(newBear, title='Sell Signal', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -104,11 +104,11 @@ var float activeLongTP = na
 var float activeShortTP = na
 
 if longSignal and strategy.position_size == 0
-    strategy.entry('Long', strategy.long)
+    strategy.entry("Long", strategy.long)
     enteredThisBlock := true
 
 if shortSignal and strategy.position_size == 0
-    strategy.entry('Short', strategy.short)
+    strategy.entry("Short", strategy.short)
     enteredThisBlock := true
 
 newLong = strategy.position_size > 0 and strategy.position_size[1] == 0
@@ -125,9 +125,9 @@ if newShort
     activeShortTP := entryPrice - stopPoints * takeProfitMultiplier
 
 if strategy.position_size > 0
-    strategy.exit('Long Exit', 'Long', stop=activeLongStop, limit=activeLongTP)
+    strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
 if strategy.position_size < 0
-    strategy.exit('Short Exit', 'Short', stop=activeShortStop, limit=activeShortTP)
+    strategy.exit("Short Exit", "Short", stop=activeShortStop, limit=activeShortTP)
 
 maeLong = strategy.position_size > 0 ? strategy.position_avg_price - low : na
 maeShort = strategy.position_size < 0 ? high - strategy.position_avg_price : na

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -50,8 +50,8 @@ bearCVD = cvdDelta < -cvdThreshold
 // Buy/sell signals only when T3 and CVD are aligned.
 bullAligned = basicLongT3 and bullCVD
 bearAligned = basicShortT3 and bearCVD
-newBull = bullAligned and not bullAligned[1]
-newBear = bearAligned and not bearAligned[1]
+newBull = bullAligned and not bullAligned[1] and barstate.isconfirmed
+newBear = bearAligned and not bearAligned[1] and barstate.isconfirmed
 
 // Session state
 inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
@@ -105,11 +105,9 @@ var float activeShortTP = na
 
 if longSignal and strategy.position_size == 0
     strategy.entry("Long", strategy.long)
-    enteredThisBlock := true
 
 if shortSignal and strategy.position_size == 0
     strategy.entry("Short", strategy.short)
-    enteredThisBlock := true
 
 newLong = strategy.position_size > 0 and strategy.position_size[1] == 0
 newShort = strategy.position_size < 0 and strategy.position_size[1] == 0
@@ -118,24 +116,18 @@ if newLong
     entryPrice = strategy.position_avg_price
     activeLongStop := entryPrice - stopPoints
     activeLongTP := entryPrice + stopPoints * takeProfitMultiplier
+    enteredThisBlock := true
 
 if newShort
     entryPrice = strategy.position_avg_price
     activeShortStop := entryPrice + stopPoints
     activeShortTP := entryPrice - stopPoints * takeProfitMultiplier
+    enteredThisBlock := true
 
-if strategy.position_size > 0
+if strategy.position_size > 0 and not na(activeLongStop) and not na(activeLongTP)
     strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
-if strategy.position_size < 0
+if strategy.position_size < 0 and not na(activeShortStop) and not na(activeShortTP)
     strategy.exit("Short Exit", "Short", stop=activeShortStop, limit=activeShortTP)
-
-maeLong = strategy.position_size > 0 ? strategy.position_avg_price - low : na
-maeShort = strategy.position_size < 0 ? high - strategy.position_avg_price : na
-
-if strategy.position_size > 0 and maeLong > stopPoints
-    strategy.close('Long', comment='Hard SL breach')
-if strategy.position_size < 0 and maeShort > stopPoints
-    strategy.close('Short', comment='Hard SL breach')
 
 if strategy.position_size == 0
     activeLongStop := na

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -2,7 +2,7 @@
 // SZTrades Momentum Alignment Strategy v1.3 (T3 + CVD only)
 // 5m scalping variant with 6:00 open directional bias and 08:00-09:00 execution window.
 
-strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100)
+strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100, use_bar_magnifier=true)
 
 // Optimization factors
 lengthT3 = input.int(4, 'T3 Length', minval=1, group='T3')

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -27,6 +27,7 @@ slippageTicks = input.int(1, "Slippage Ticks", group="Risk")
 
 // Session controls
 tradeSession = input.session('0800-0900', 'Trading Window (HHMM-HHMM)', group='Session')
+preSession = input.session("0600-0800", "Pre-Session Window", group='Session')
 sessionTimezone = input.string("Etc/GMT+4", "Timezone", group='Session')
 
 gdT3(src, len) =>
@@ -64,14 +65,19 @@ newBear = bearAligned and not bearAligned[1] and barstate.isconfirmed
 
 // Session state
 inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
+inPreSession = not na(time(timeframe.period, preSession, sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
 
 var bool preBullAligned = false
 var bool preBearAligned = false
-if not inTradeBlock
-    preBullAligned := bullAligned
-    preBearAligned := bearAligned
+if inPreSession and bullAligned
+    preBullAligned := true
+if inPreSession and bearAligned
+    preBearAligned := true
+if blockStarted
+    preBullAligned := false
+    preBearAligned := false
 
 // Parse session end time defensively.
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
@@ -103,8 +109,10 @@ validBullContext = bullAligned or preBullAligned
 validBearContext = bearAligned or preBearAligned
 validLong = validBullContext and close > open6am
 validShort = validBearContext and close < open6am
-pullbackLong = close[1] < t3 and close > t3
-pullbackShort = close[1] > t3 and close < t3
+pullbackLong = preBullAligned and close <= t3
+reclaimLong = pullbackLong[1] and newBull and close > t3
+pullbackShort = preBearAligned and close >= t3
+reclaimShort = pullbackShort[1] and newBear and close < t3
 
 // Only execute on 5-minute charts.
 isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
@@ -119,8 +127,8 @@ if blockEnded
     enteredThisBlock := false
     orderPlaced := false
 
-longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and validLong and pullbackLong
-shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and validShort and pullbackShort
+longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and reclaimLong and allowLongBySixOpen
+shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and reclaimShort and allowShortBySixOpen
 longSignal := longSignal and barstate.isconfirmed
 shortSignal := shortSignal and barstate.isconfirmed
 

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -20,7 +20,6 @@ strategy(
 lengthT3 = input.int(4, 'T3 Length', minval=1, group='T3')
 factorT3 = input.float(0.7, 'T3 Factor', minval=0.0, maxval=1.0, group='T3')
 cumulationLength = input.int(16, 'CVD Cumulation Length', minval=1, group='CVD')
-cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, group='CVD')
 stopPoints = input.float(4.0, 'Stop Points', minval=0.0, group='Risk')
 takeProfitMultiplier = input.float(2.0, 'Take Profit Multiplier', minval=0.1, group='Risk')
 slippageTicks = input.int(1, "Slippage Ticks", group="Risk")
@@ -53,6 +52,8 @@ sellingVolume = close < open ? (percentBody + halfWicks) * volume : halfWicks * 
 cumBuy = ta.ema(buyingVolume, cumulationLength)
 cumSell = ta.ema(sellingVolume, cumulationLength)
 cvdDelta = cumBuy - cumSell
+cvdStd = ta.stdev(cvdDelta, 20)
+cvdThreshold = cvdStd * 0.5
 bullCVD = cvdDelta > cvdThreshold
 bearCVD = cvdDelta < -cvdThreshold
 
@@ -119,39 +120,15 @@ if reclaimLong
 if reclaimShort
     reclaimedShort := true
 
-atrLen = 14
-atr = ta.atr(atrLen)
-preRange = preHigh - preLow
-validPreSession = not na(preHigh) and not na(preLow)
-isCompressed = validPreSession and preRange < atr
-isExpanding = (high - low) > atr
-validBullSignal = newBull and reclaimedLong
-validBearSignal = newBear and reclaimedShort
+atr = ta.atr(14)
+atrMA = ta.sma(atr, 20)
+validVolatility = atr > atrMA
+minDistance = atr * 0.5
+farFromOpen = not na(open6am) and math.abs(close - open6am) > minDistance
 
-// 1. Sweep already occurred.
-hasSweepLong = sweptLow
-hasSweepShort = sweptHigh
-
-// 2. Reclaim.
-hasReclaimLong = reclaimedLong
-hasReclaimShort = reclaimedShort
-
-// 3. Pullback.
-hasPullbackLong = hasReclaimLong and low <= t3
-hasPullbackShort = hasReclaimShort and high >= t3
-
-// 4. Expansion.
-hasExpansion = isCompressed and isExpanding
-
-barsSinceSweepLow = ta.barssince(sweepLow)
-barsSinceSweepHigh = ta.barssince(sweepHigh)
-validTimingLong = barsSinceSweepLow > 1
-validTimingShort = barsSinceSweepHigh > 1
-strongBody = math.abs(close - open) > (high - low) * 0.6
-
-// 5. Final trigger.
-triggerLong = hasSweepLong and hasPullbackLong and hasExpansion and validBullSignal and strongBody
-triggerShort = hasSweepShort and hasPullbackShort and hasExpansion and validBearSignal and strongBody
+minuteOfDay = hour(time, sessionTimezone) * 60 + minute(time, sessionTimezone)
+sessionStart = 8 * 60
+allowEarly = minuteOfDay <= (sessionStart + 30)
 
 // Parse session end time defensively.
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
@@ -175,13 +152,8 @@ isSixAMBar = hour(time, sessionTimezone) == 6 and minute(time, sessionTimezone) 
 if isSixAMBar
     open6am := open
 showSixOpenLine = not na(time(timeframe.period, '0600-1000', sessionTimezone))
-
 allowLongBySixOpen = not na(open6am) and close > open6am
 allowShortBySixOpen = not na(open6am) and close < open6am
-pullbackLong = close < t3
-pullbackShort = close > t3
-reclaimBull = bullAligned and pullbackLong[1]
-reclaimBear = bearAligned and pullbackShort[1]
 
 // Only execute on 5-minute charts.
 isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
@@ -196,12 +168,8 @@ if blockEnded
     enteredThisBlock := false
     orderPlaced := false
 
-longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and preAlignedBull and reclaimBull and allowLongBySixOpen
-shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and preAlignedBear and reclaimBear and allowShortBySixOpen
-tooFarLong = close > t3 * 1.002
-tooFarShort = close < t3 * 0.998
-longSignal := longSignal and not tooFarLong
-shortSignal := shortSignal and not tooFarShort
+longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBull and allowLongBySixOpen and validVolatility and farFromOpen and allowEarly
+shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBear and allowShortBySixOpen and validVolatility and farFromOpen and allowEarly
 longSignal := longSignal and barstate.isconfirmed
 shortSignal := shortSignal and barstate.isconfirmed
 
@@ -256,5 +224,6 @@ plot(strategy.position_size > 0 ? activeLongTP : na, "Long TP", color=color.gree
 plot(preHigh, "Pre High", color=color.red)
 plot(preLow, "Pre Low", color=color.green)
 plot(atr, "ATR", color=color.blue)
+plot(atrMA, "ATR MA", color=color.orange)
 plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
 plotshape(newBear, title='Sell Signal', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -97,6 +97,8 @@ if blockEnded
 
 longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBull and allowLongBySixOpen
 shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBear and allowShortBySixOpen
+longSignal := longSignal and barstate.isconfirmed
+shortSignal := shortSignal and barstate.isconfirmed
 
 var float activeLongStop = na
 var float activeShortStop = na
@@ -117,16 +119,13 @@ if newLong
     activeLongStop := entryPrice - stopPoints
     activeLongTP := entryPrice + stopPoints * takeProfitMultiplier
     enteredThisBlock := true
+    strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
 
 if newShort
     entryPrice = strategy.position_avg_price
     activeShortStop := entryPrice + stopPoints
     activeShortTP := entryPrice - stopPoints * takeProfitMultiplier
     enteredThisBlock := true
-
-if strategy.position_size > 0 and not na(activeLongStop) and not na(activeLongTP)
-    strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
-if strategy.position_size < 0 and not na(activeShortStop) and not na(activeShortTP)
     strategy.exit("Short Exit", "Short", stop=activeShortStop, limit=activeShortTP)
 
 if strategy.position_size == 0
@@ -137,10 +136,12 @@ if strategy.position_size == 0
 
 // Forced close at block end, always on.
 if lastBarOfBlock and strategy.position_size != 0
-    strategy.close_all(comment='Block end close', immediately=true)
+    strategy.close_all(comment='Block end close')
 
 bgcolor(bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na)
 plot(t3, title='T3', linewidth=2, color=t3Color)
 plot(showSixOpenLine ? open6am : na, title='06:00 Open', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
+plot(strategy.position_size > 0 ? activeLongStop : na, "Long SL", color=color.red)
+plot(strategy.position_size > 0 ? activeLongTP : na, "Long TP", color=color.green)
 plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
 plotshape(newBear, title='Sell Signal', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -93,6 +93,19 @@ if blockStarted
     sweptHigh := false
     sweptLow := false
 
+reclaimLong = sweptLow and close > preLow
+reclaimShort = sweptHigh and close < preHigh
+
+var bool reclaimedLong = false
+var bool reclaimedShort = false
+if reclaimLong
+    reclaimedLong := true
+if reclaimShort
+    reclaimedShort := true
+if blockStarted
+    reclaimedLong := false
+    reclaimedShort := false
+
 atr = ta.atr(atrLen)
 atrMA = ta.sma(atr, atrMaLen)
 isCompressed = atr < atrMA * atrCompressionThreshold
@@ -130,10 +143,10 @@ showSixOpenLine = not na(time(timeframe.period, '0600-1000', sessionTimezone))
 
 allowLongBySixOpen = not na(open6am) and close > open6am
 allowShortBySixOpen = not na(open6am) and close < open6am
-pullbackLong = basicLongT3 and close < t3
-reclaimLong = basicLongT3 and close > t3 and close[1] < t3
-pullbackShort = basicShortT3 and close > t3
-reclaimShort = basicShortT3 and close < t3 and close[1] > t3
+pullbackLong = reclaimedLong and low <= t3
+pullbackShort = reclaimedShort and high >= t3
+triggerLong = pullbackLong and newBull
+triggerShort = pullbackShort and newBear
 
 // Only execute on 5-minute charts.
 isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
@@ -152,23 +165,15 @@ longSignal =
     isFiveMinuteChart and
     inTradeBlock and
     not enteredThisBlock and
-    reclaimLong and
-    bullCVD and
-    allowLongBySixOpen and
-    preSessionCompression and
-    isExpanding and
-    sweptLow
+    triggerLong and
+    allowLongBySixOpen
 
 shortSignal =
     isFiveMinuteChart and
     inTradeBlock and
     not enteredThisBlock and
-    reclaimShort and
-    bearCVD and
-    allowShortBySixOpen and
-    preSessionCompression and
-    isExpanding and
-    sweptHigh
+    triggerShort and
+    allowShortBySixOpen
 longSignal := longSignal and barstate.isconfirmed
 shortSignal := shortSignal and barstate.isconfirmed
 

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -103,42 +103,38 @@ var float activeLongTP = na
 var float activeShortTP = na
 
 if longSignal and strategy.position_size == 0
-    strategy.entry('Long', strategy.long, comment='Buy signal')
+    strategy.entry('Long', strategy.long)
     enteredThisBlock := true
 
 if shortSignal and strategy.position_size == 0
-    strategy.entry('Short', strategy.short, comment='Sell signal')
+    strategy.entry('Short', strategy.short)
     enteredThisBlock := true
 
 newLong = strategy.position_size > 0 and strategy.position_size[1] == 0
 newShort = strategy.position_size < 0 and strategy.position_size[1] == 0
 
 if newLong
-    entry = strategy.position_avg_price
-    activeLongStop := entry - stopPoints
-    activeLongTP := entry + stopPoints * takeProfitMultiplier
-    activeShortStop := na
-    activeShortTP := na
+    entryPrice = strategy.position_avg_price
+    activeLongStop := entryPrice - stopPoints
+    activeLongTP := entryPrice + stopPoints * takeProfitMultiplier
 
 if newShort
-    entry = strategy.position_avg_price
-    activeShortStop := entry + stopPoints
-    activeShortTP := entry - stopPoints * takeProfitMultiplier
-    activeLongStop := na
-    activeLongTP := na
+    entryPrice = strategy.position_avg_price
+    activeShortStop := entryPrice + stopPoints
+    activeShortTP := entryPrice - stopPoints * takeProfitMultiplier
 
-if strategy.position_size > 0 and not na(activeLongStop)
+if strategy.position_size > 0
     strategy.exit('Long Exit', 'Long', stop=activeLongStop, limit=activeLongTP)
-if strategy.position_size < 0 and not na(activeShortStop)
+if strategy.position_size < 0
     strategy.exit('Short Exit', 'Short', stop=activeShortStop, limit=activeShortTP)
 
 maeLong = strategy.position_size > 0 ? strategy.position_avg_price - low : na
 maeShort = strategy.position_size < 0 ? high - strategy.position_avg_price : na
 
 if strategy.position_size > 0 and maeLong > stopPoints
-    strategy.close('Long', comment='Hard SL')
+    strategy.close('Long', comment='Hard SL breach')
 if strategy.position_size < 0 and maeShort > stopPoints
-    strategy.close('Short', comment='Hard SL')
+    strategy.close('Short', comment='Hard SL breach')
 
 if strategy.position_size == 0
     activeLongStop := na

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -23,7 +23,7 @@ cumulationLength = input.int(16, 'CVD Cumulation Length', minval=1, group='CVD')
 cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, group='CVD')
 stopPoints = input.float(4.0, 'Stop Points', minval=0.0, group='Risk')
 takeProfitMultiplier = input.float(2.0, 'Take Profit Multiplier', minval=0.1, group='Risk')
-slippageTicks = input.int(1, "Slippage Ticks", minval=0, group='Risk')
+slippageTicks = input.int(1, "Slippage Ticks", group="Risk")
 
 // Session controls
 tradeSession = input.session('0800-0900', 'Trading Window (HHMM-HHMM)', group='Session')

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -5,12 +5,12 @@
 strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100)
 
 // Optimization factors
-lengthT3 = input.int(4, 'T3 Length', minval=4, maxval=8, step=2, group='T3')
-factorT3 = input.float(0.7, 'T3 Factor', minval=0.5, maxval=0.9, step=0.2, group='T3')
-cumulationLength = input.int(16, 'CVD Cumulation Length', minval=8, maxval=24, step=8, group='CVD')
-cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, maxval=60.0, step=20.0, group='CVD')
-stopPoints = input.float(4.0, 'Stop Points', minval=2.0, maxval=8.0, step=2.0, group='Risk')
-takeProfitMultiplier = input.float(2.0, 'Take Profit Multiplier', minval=2.0, maxval=5.0, step=0.5, group='Risk')
+lengthT3 = input.int(4, 'T3 Length', minval=1, group='T3')
+factorT3 = input.float(0.7, 'T3 Factor', minval=0.0, maxval=1.0, group='T3')
+cumulationLength = input.int(16, 'CVD Cumulation Length', minval=1, group='CVD')
+cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, group='CVD')
+stopPoints = input.float(4.0, 'Stop Points', minval=0.0, group='Risk')
+takeProfitMultiplier = input.float(2.0, 'Take Profit Multiplier', minval=0.1, group='Risk')
 
 // Session controls
 tradeSession = input.session('0800-0900', 'Trading Window (HHMM-HHMM)', group='Session')

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -5,7 +5,8 @@
 strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true,
      max_labels_count=500, max_lines_count=500, pyramiding=0,
      default_qty_type=strategy.percent_of_equity, default_qty_value=100,
-     use_bar_magnifier=true, calc_on_every_tick=true, process_orders_on_close=false)
+     use_bar_magnifier=true, calc_on_every_tick=true, process_orders_on_close=false,
+     commission_type=strategy.commission.percent, commission_value=0.01, slippage=1)
 
 // Optimization factors
 lengthT3 = input.int(4, 'T3 Length', minval=1, group='T3')

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -24,10 +24,12 @@ cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, group='CVD')
 stopPoints = input.float(4.0, 'Stop Points', minval=0.0, group='Risk')
 takeProfitMultiplier = input.float(2.0, 'Take Profit Multiplier', minval=0.1, group='Risk')
 slippageTicks = input.int(1, "Slippage Ticks", group="Risk")
+atrLen = input.int(14, "ATR Length", group="ATR")
+atrMaLen = input.int(50, "ATR MA Length", group="ATR")
+atrCompressionThreshold = input.float(0.8, "ATR Compression Threshold", group="ATR")
 
 // Session controls
 tradeSession = input.session('0800-0900', 'Trading Window (HHMM-HHMM)', group='Session')
-preSession = input.session("0600-0800", "Pre-Session Window", group='Session')
 sessionTimezone = input.string("Etc/GMT+4", "Timezone", group='Session')
 
 gdT3(src, len) =>
@@ -65,19 +67,20 @@ newBear = bearAligned and not bearAligned[1] and barstate.isconfirmed
 
 // Session state
 inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
-inPreSession = not na(time(timeframe.period, preSession, sessionTimezone))
+inPreSession = not na(time(timeframe.period, "0600-0800", sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
 
-var bool preBullAligned = false
-var bool preBearAligned = false
-if inPreSession and bullAligned
-    preBullAligned := true
-if inPreSession and bearAligned
-    preBearAligned := true
+atr = ta.atr(atrLen)
+atrMA = ta.sma(atr, atrMaLen)
+isCompressed = atr < atrMA * atrCompressionThreshold
+isExpanding = atr > atr[1]
+
+var bool preSessionCompression = false
+if inPreSession and isCompressed
+    preSessionCompression := true
 if blockStarted
-    preBullAligned := false
-    preBearAligned := false
+    preSessionCompression := false
 
 // Parse session end time defensively.
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
@@ -105,14 +108,10 @@ showSixOpenLine = not na(time(timeframe.period, '0600-1000', sessionTimezone))
 
 allowLongBySixOpen = not na(open6am) and close > open6am
 allowShortBySixOpen = not na(open6am) and close < open6am
-validBullContext = bullAligned or preBullAligned
-validBearContext = bearAligned or preBearAligned
-validLong = validBullContext and close > open6am
-validShort = validBearContext and close < open6am
-pullbackLong = preBullAligned and close <= t3
-reclaimLong = pullbackLong[1] and newBull and close > t3
-pullbackShort = preBearAligned and close >= t3
-reclaimShort = pullbackShort[1] and newBear and close < t3
+pullbackLong = basicLongT3 and close < t3
+reclaimLong = basicLongT3 and close > t3 and close[1] < t3
+pullbackShort = basicShortT3 and close > t3
+reclaimShort = basicShortT3 and close < t3 and close[1] > t3
 
 // Only execute on 5-minute charts.
 isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
@@ -127,8 +126,25 @@ if blockEnded
     enteredThisBlock := false
     orderPlaced := false
 
-longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and reclaimLong and allowLongBySixOpen
-shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and reclaimShort and allowShortBySixOpen
+longSignal =
+    isFiveMinuteChart and
+    inTradeBlock and
+    not enteredThisBlock and
+    reclaimLong and
+    bullCVD and
+    allowLongBySixOpen and
+    preSessionCompression and
+    isExpanding
+
+shortSignal =
+    isFiveMinuteChart and
+    inTradeBlock and
+    not enteredThisBlock and
+    reclaimShort and
+    bearCVD and
+    allowShortBySixOpen and
+    preSessionCompression and
+    isExpanding
 longSignal := longSignal and barstate.isconfirmed
 shortSignal := shortSignal and barstate.isconfirmed
 
@@ -180,5 +196,7 @@ plot(t3, title='T3', linewidth=2, color=t3Color)
 plot(showSixOpenLine ? open6am : na, title='06:00 Open', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
 plot(strategy.position_size > 0 ? activeLongStop : na, "Long SL", color=color.red)
 plot(strategy.position_size > 0 ? activeLongTP : na, "Long TP", color=color.green)
+plot(atr, "ATR", color=color.blue)
+plot(atrMA, "ATR MA", color=color.orange)
 plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
 plotshape(newBear, title='Sell Signal', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -2,7 +2,7 @@
 // SZTrades Momentum Alignment Strategy v1.3 (T3 + CVD only)
 // 5m scalping variant with 6:00 open directional bias and 08:00-09:00 execution window.
 
-strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100, use_bar_magnifier=true)
+strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100, use_bar_magnifier=true, calc_on_every_tick=true, process_orders_on_close=false)
 
 // Optimization factors
 lengthT3 = input.int(4, 'T3 Length', minval=1, group='T3')
@@ -93,25 +93,17 @@ if blockEnded
 
 longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBull and allowLongBySixOpen
 shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBear and allowShortBySixOpen
-longStopFromSignal = low - stopPoints
-shortStopFromSignal = high + stopPoints
 
-var float pendingLongStop = na
-var float pendingShortStop = na
 var float activeLongStop = na
 var float activeShortStop = na
 var float activeLongTP = na
 var float activeShortTP = na
 
 if longSignal and strategy.position_size == 0
-    pendingLongStop := longStopFromSignal
-    pendingShortStop := na
     strategy.entry('Long', strategy.long, comment='Buy signal')
     enteredThisBlock := true
 
 if shortSignal and strategy.position_size == 0
-    pendingShortStop := shortStopFromSignal
-    pendingLongStop := na
     strategy.entry('Short', strategy.short, comment='Sell signal')
     enteredThisBlock := true
 
@@ -119,17 +111,15 @@ newLongPosition = strategy.position_size > 0 and strategy.position_size[1] <= 0
 newShortPosition = strategy.position_size < 0 and strategy.position_size[1] >= 0
 
 if newLongPosition
-    activeLongStop := pendingLongStop
+    activeLongStop := strategy.position_avg_price - stopPoints
     activeShortStop := na
-    longRisk = strategy.position_avg_price - activeLongStop
-    activeLongTP := longRisk > 0 ? strategy.position_avg_price + longRisk * takeProfitMultiplier : na
+    activeLongTP := strategy.position_avg_price + stopPoints * takeProfitMultiplier
     activeShortTP := na
 
 if newShortPosition
-    activeShortStop := pendingShortStop
+    activeShortStop := strategy.position_avg_price + stopPoints
     activeLongStop := na
-    shortRisk = activeShortStop - strategy.position_avg_price
-    activeShortTP := shortRisk > 0 ? strategy.position_avg_price - shortRisk * takeProfitMultiplier : na
+    activeShortTP := strategy.position_avg_price - stopPoints * takeProfitMultiplier
     activeLongTP := na
 
 if strategy.position_size > 0 and not na(activeLongStop)
@@ -146,8 +136,6 @@ if strategy.position_size == 0
 // Forced close at block end, always on.
 if lastBarOfBlock and strategy.position_size != 0
     strategy.close_all(comment='Block end close', immediately=true)
-    pendingLongStop := na
-    pendingShortStop := na
 
 bgcolor(bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na)
 plot(t3, title='T3', linewidth=2, color=t3Color)

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -71,6 +71,28 @@ inPreSession = not na(time(timeframe.period, "0600-0800", sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
 
+var float preHigh = na
+var float preLow = na
+if inPreSession
+    preHigh := na(preHigh) ? high : math.max(preHigh, high)
+    preLow := na(preLow) ? low : math.min(preLow, low)
+if blockStarted
+    preHigh := na
+    preLow := na
+
+sweepHigh = high > preHigh and close < preHigh
+sweepLow = low < preLow and close > preLow
+
+var bool sweptHigh = false
+var bool sweptLow = false
+if sweepHigh
+    sweptHigh := true
+if sweepLow
+    sweptLow := true
+if blockStarted
+    sweptHigh := false
+    sweptLow := false
+
 atr = ta.atr(atrLen)
 atrMA = ta.sma(atr, atrMaLen)
 isCompressed = atr < atrMA * atrCompressionThreshold
@@ -134,7 +156,8 @@ longSignal =
     bullCVD and
     allowLongBySixOpen and
     preSessionCompression and
-    isExpanding
+    isExpanding and
+    sweptLow
 
 shortSignal =
     isFiveMinuteChart and
@@ -144,7 +167,8 @@ shortSignal =
     bearCVD and
     allowShortBySixOpen and
     preSessionCompression and
-    isExpanding
+    isExpanding and
+    sweptHigh
 longSignal := longSignal and barstate.isconfirmed
 shortSignal := shortSignal and barstate.isconfirmed
 
@@ -196,6 +220,8 @@ plot(t3, title='T3', linewidth=2, color=t3Color)
 plot(showSixOpenLine ? open6am : na, title='06:00 Open', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
 plot(strategy.position_size > 0 ? activeLongStop : na, "Long SL", color=color.red)
 plot(strategy.position_size > 0 ? activeLongTP : na, "Long TP", color=color.green)
+plot(preHigh, "Pre High", color=color.red)
+plot(preLow, "Pre Low", color=color.green)
 plot(atr, "ATR", color=color.blue)
 plot(atrMA, "ATR MA", color=color.orange)
 plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -2,11 +2,19 @@
 // SZTrades Momentum Alignment Strategy v1.3 (T3 + CVD only)
 // 5m scalping variant with 6:00 open directional bias and 08:00-09:00 execution window.
 
-strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true,
-     max_labels_count=500, max_lines_count=500, pyramiding=0,
-     default_qty_type=strategy.percent_of_equity, default_qty_value=100,
-     calc_on_every_tick=false, process_orders_on_close=true,
-     commission_type=strategy.commission.percent, commission_value=0.01)
+strategy(
+    'SZTrades Momentum Alignment Strategy v1.3',
+    shorttitle='SZT1.3',
+    overlay=true,
+    pyramiding=0,
+    default_qty_type=strategy.percent_of_equity,
+    default_qty_value=100,
+    calc_on_every_tick=false,
+    process_orders_on_close=true,
+    commission_type=strategy.commission.percent,
+    commission_value=0.01,
+    slippage=1
+)
 
 // Optimization factors
 lengthT3 = input.int(4, 'T3 Length', minval=1, group='T3')
@@ -15,7 +23,7 @@ cumulationLength = input.int(16, 'CVD Cumulation Length', minval=1, group='CVD')
 cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, group='CVD')
 stopPoints = input.float(4.0, 'Stop Points', minval=0.0, group='Risk')
 takeProfitMultiplier = input.float(2.0, 'Take Profit Multiplier', minval=0.1, group='Risk')
-slippageTicks = input.int(1, 'Slippage (ticks)', minval=0, group='Risk')
+slippageTicks = input.int(1, "Slippage Ticks", minval=0, group='Risk')
 
 // Session controls
 tradeSession = input.session('0800-0900', 'Trading Window (HHMM-HHMM)', group='Session')

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -105,19 +105,40 @@ var float activeShortTP = na
 if longSignal and strategy.position_size == 0
     strategy.entry('Long', strategy.long, comment='Buy signal')
     enteredThisBlock := true
-    activeLongStop := strategy.position_avg_price - stopPoints
-    activeLongTP := strategy.position_avg_price + stopPoints * takeProfitMultiplier
 
 if shortSignal and strategy.position_size == 0
     strategy.entry('Short', strategy.short, comment='Sell signal')
     enteredThisBlock := true
-    activeShortStop := strategy.position_avg_price + stopPoints
-    activeShortTP := strategy.position_avg_price - stopPoints * takeProfitMultiplier
+
+newLong = strategy.position_size > 0 and strategy.position_size[1] == 0
+newShort = strategy.position_size < 0 and strategy.position_size[1] == 0
+
+if newLong
+    entry = strategy.position_avg_price
+    activeLongStop := entry - stopPoints
+    activeLongTP := entry + stopPoints * takeProfitMultiplier
+    activeShortStop := na
+    activeShortTP := na
+
+if newShort
+    entry = strategy.position_avg_price
+    activeShortStop := entry + stopPoints
+    activeShortTP := entry - stopPoints * takeProfitMultiplier
+    activeLongStop := na
+    activeLongTP := na
 
 if strategy.position_size > 0 and not na(activeLongStop)
     strategy.exit('Long Exit', 'Long', stop=activeLongStop, limit=activeLongTP)
 if strategy.position_size < 0 and not na(activeShortStop)
     strategy.exit('Short Exit', 'Short', stop=activeShortStop, limit=activeShortTP)
+
+maeLong = strategy.position_size > 0 ? strategy.position_avg_price - low : na
+maeShort = strategy.position_size < 0 ? high - strategy.position_avg_price : na
+
+if strategy.position_size > 0 and maeLong > stopPoints
+    strategy.close('Long', comment='Hard SL')
+if strategy.position_size < 0 and maeShort > stopPoints
+    strategy.close('Short', comment='Hard SL')
 
 if strategy.position_size == 0
     activeLongStop := na

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -90,10 +90,13 @@ isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
 
 // Only first fresh signal inside each block. No re-entry until close.
 var bool enteredThisBlock = false
+var bool orderPlaced = false
 if blockStarted
     enteredThisBlock := false
+    orderPlaced := false
 if blockEnded
     enteredThisBlock := false
+    orderPlaced := false
 
 longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBull and allowLongBySixOpen
 shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBear and allowShortBySixOpen
@@ -105,23 +108,25 @@ var float activeShortStop = na
 var float activeLongTP = na
 var float activeShortTP = na
 
-if longSignal and strategy.position_size == 0
+if longSignal and not orderPlaced and strategy.position_size == 0
     strategy.entry("Long", strategy.long)
+    orderPlaced := true
 
-if shortSignal and strategy.position_size == 0
+if shortSignal and not orderPlaced and strategy.position_size == 0
     strategy.entry("Short", strategy.short)
+    orderPlaced := true
 
 newLong = strategy.position_size > 0 and strategy.position_size[1] == 0
 newShort = strategy.position_size < 0 and strategy.position_size[1] == 0
 
-if newLong
+if newLong and na(activeLongStop)
     entryPrice = strategy.position_avg_price
     activeLongStop := entryPrice - stopPoints
     activeLongTP := entryPrice + stopPoints * takeProfitMultiplier
     enteredThisBlock := true
     strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
 
-if newShort
+if newShort and na(activeShortStop)
     entryPrice = strategy.position_avg_price
     activeShortStop := entryPrice + stopPoints
     activeShortTP := entryPrice - stopPoints * takeProfitMultiplier

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -67,6 +67,12 @@ inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
 
+var bool preBullAligned = false
+var bool preBearAligned = false
+if not inTradeBlock
+    preBullAligned := bullAligned
+    preBearAligned := bearAligned
+
 // Parse session end time defensively.
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
 sessionRanges = str.split(sessionCore, ",")
@@ -93,6 +99,12 @@ showSixOpenLine = not na(time(timeframe.period, '0600-1000', sessionTimezone))
 
 allowLongBySixOpen = not na(open6am) and close > open6am
 allowShortBySixOpen = not na(open6am) and close < open6am
+validBullContext = bullAligned or preBullAligned
+validBearContext = bearAligned or preBearAligned
+validLong = validBullContext and close > open6am
+validShort = validBearContext and close < open6am
+pullbackLong = close[1] < t3 and close > t3
+pullbackShort = close[1] > t3 and close < t3
 
 // Only execute on 5-minute charts.
 isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
@@ -107,8 +119,8 @@ if blockEnded
     enteredThisBlock := false
     orderPlaced := false
 
-longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBull and allowLongBySixOpen
-shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBear and allowShortBySixOpen
+longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and validLong and pullbackLong
+shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and validShort and pullbackShort
 longSignal := longSignal and barstate.isconfirmed
 shortSignal := shortSignal and barstate.isconfirmed
 

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -24,9 +24,6 @@ cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, group='CVD')
 stopPoints = input.float(4.0, 'Stop Points', minval=0.0, group='Risk')
 takeProfitMultiplier = input.float(2.0, 'Take Profit Multiplier', minval=0.1, group='Risk')
 slippageTicks = input.int(1, "Slippage Ticks", group="Risk")
-atrLen = input.int(14, "ATR Length", group="ATR")
-atrMaLen = input.int(50, "ATR MA Length", group="ATR")
-atrCompressionThreshold = input.float(0.8, "ATR Compression Threshold", group="ATR")
 
 // Session controls
 tradeSession = input.session('0800-0900', 'Trading Window (HHMM-HHMM)', group='Session')
@@ -106,16 +103,13 @@ if blockStarted
     reclaimedLong := false
     reclaimedShort := false
 
+atrLen = 14
 atr = ta.atr(atrLen)
-atrMA = ta.sma(atr, atrMaLen)
-isCompressed = atr < atrMA * atrCompressionThreshold
-isExpanding = atr > atr[1]
-
-var bool preSessionCompression = false
-if inPreSession and isCompressed
-    preSessionCompression := true
-if blockStarted
-    preSessionCompression := false
+preRange = preHigh - preLow
+isCompressed = preRange < atr
+isExpanding = (high - low) > atr
+validExpansionLong = isCompressed and isExpanding
+validExpansionShort = isCompressed and isExpanding
 
 // Parse session end time defensively.
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
@@ -166,14 +160,16 @@ longSignal =
     inTradeBlock and
     not enteredThisBlock and
     triggerLong and
-    allowLongBySixOpen
+    allowLongBySixOpen and
+    validExpansionLong
 
 shortSignal =
     isFiveMinuteChart and
     inTradeBlock and
     not enteredThisBlock and
     triggerShort and
-    allowShortBySixOpen
+    allowShortBySixOpen and
+    validExpansionShort
 longSignal := longSignal and barstate.isconfirmed
 shortSignal := shortSignal and barstate.isconfirmed
 
@@ -228,6 +224,5 @@ plot(strategy.position_size > 0 ? activeLongTP : na, "Long TP", color=color.gree
 plot(preHigh, "Pre High", color=color.red)
 plot(preLow, "Pre Low", color=color.green)
 plot(atr, "ATR", color=color.blue)
-plot(atrMA, "ATR MA", color=color.orange)
 plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
 plotshape(newBear, title='Sell Signal', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -1,0 +1,155 @@
+//@version=6
+// SZTrades Momentum Alignment Strategy v1.3 (T3 + CVD only)
+// 5m scalping variant with 6:00 open directional bias and 08:00-09:00 execution window.
+
+strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100)
+
+// Optimization factors
+lengthT3 = input.int(4, 'T3 Length', minval=4, maxval=8, step=2, group='T3')
+factorT3 = input.float(0.7, 'T3 Factor', minval=0.5, maxval=0.9, step=0.2, group='T3')
+cumulationLength = input.int(16, 'CVD Cumulation Length', minval=8, maxval=24, step=8, group='CVD')
+cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, maxval=60.0, step=20.0, group='CVD')
+stopPoints = input.float(4.0, 'Stop Points', minval=2.0, maxval=8.0, step=2.0, group='Risk')
+takeProfitMultiplier = input.float(2.0, 'Take Profit Multiplier', minval=2.0, maxval=5.0, step=0.5, group='Risk')
+
+// Session controls
+tradeSession = input.session('0800-0900', 'Trading Window (HHMM-HHMM)', group='Session')
+sessionTimezone = 'Etc/GMT+4'
+
+gdT3(src, len) =>
+    ta.ema(src, len) * (1 + factorT3) - ta.ema(ta.ema(src, len), len) * factorT3
+
+// T3 core
+t3 = gdT3(gdT3(gdT3(close, lengthT3), lengthT3), lengthT3)
+t3Direction = t3 > t3[1] ? 1 : t3 < t3[1] ? -1 : 0
+t3Color = t3Direction > 0 ? color.green : color.red
+basicLongT3 = t3Direction > 0 and close > t3
+basicShortT3 = t3Direction < 0 and close < t3
+
+// CVD core
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpper = upperWick / spread
+percentLower = lowerWick / spread
+percentBody = bodyLength / spread
+halfWicks = (percentUpper + percentLower) / 2
+buyingVolume = close > open ? (percentBody + halfWicks) * volume : halfWicks * volume
+sellingVolume = close < open ? (percentBody + halfWicks) * volume : halfWicks * volume
+cumBuy = ta.ema(buyingVolume, cumulationLength)
+cumSell = ta.ema(sellingVolume, cumulationLength)
+cvdDelta = cumBuy - cumSell
+bullCVD = cvdDelta > cvdThreshold
+bearCVD = cvdDelta < -cvdThreshold
+
+// Buy/sell signals only when T3 and CVD are aligned.
+bullAligned = basicLongT3 and bullCVD
+bearAligned = basicShortT3 and bearCVD
+newBull = bullAligned and not bullAligned[1]
+newBear = bearAligned and not bearAligned[1]
+
+// Session state
+inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
+blockStarted = inTradeBlock and not inTradeBlock[1]
+blockEnded = not inTradeBlock and inTradeBlock[1]
+
+// Parse session end time defensively.
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ''
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ''
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidEnd = str.length(endTokenClean) >= 4
+endHourRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+sessionEndHour = (hasValidEnd and not na(endHourRaw)) ? int(endHourRaw) : 0
+sessionEndMinute = (hasValidEnd and not na(endMinuteRaw)) ? int(endMinuteRaw) : 0
+sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
+lastBarOfBlockByClock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
+lastBarOfBlock = hasValidEnd ? lastBarOfBlockByClock : blockEnded
+
+// Directional bias from 06:00 open (same timezone).
+isSixAMBar = hour(time, sessionTimezone) == 6 and minute(time, sessionTimezone) == 0
+var float open6am = na
+if isSixAMBar
+    open6am := open
+
+allowLongBySixOpen = not na(open6am) and close > open6am
+allowShortBySixOpen = not na(open6am) and close < open6am
+
+// Only execute on 5-minute charts.
+isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
+
+// Only first fresh signal inside each block. No re-entry until close.
+var bool enteredThisBlock = false
+if blockStarted
+    enteredThisBlock := false
+if blockEnded
+    enteredThisBlock := false
+
+longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBull and allowLongBySixOpen
+shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBear and allowShortBySixOpen
+longStopFromSignal = low - stopPoints
+shortStopFromSignal = high + stopPoints
+
+var float pendingLongStop = na
+var float pendingShortStop = na
+var float activeLongStop = na
+var float activeShortStop = na
+var float activeLongTP = na
+var float activeShortTP = na
+
+if longSignal and strategy.position_size == 0
+    pendingLongStop := longStopFromSignal
+    pendingShortStop := na
+    strategy.entry('Long', strategy.long, comment='Buy signal')
+    enteredThisBlock := true
+
+if shortSignal and strategy.position_size == 0
+    pendingShortStop := shortStopFromSignal
+    pendingLongStop := na
+    strategy.entry('Short', strategy.short, comment='Sell signal')
+    enteredThisBlock := true
+
+newLongPosition = strategy.position_size > 0 and strategy.position_size[1] <= 0
+newShortPosition = strategy.position_size < 0 and strategy.position_size[1] >= 0
+
+if newLongPosition
+    activeLongStop := pendingLongStop
+    activeShortStop := na
+    longRisk = strategy.position_avg_price - activeLongStop
+    activeLongTP := longRisk > 0 ? strategy.position_avg_price + longRisk * takeProfitMultiplier : na
+    activeShortTP := na
+
+if newShortPosition
+    activeShortStop := pendingShortStop
+    activeLongStop := na
+    shortRisk = activeShortStop - strategy.position_avg_price
+    activeShortTP := shortRisk > 0 ? strategy.position_avg_price - shortRisk * takeProfitMultiplier : na
+    activeLongTP := na
+
+if strategy.position_size > 0 and not na(activeLongStop)
+    strategy.exit('Long Exit', 'Long', stop=activeLongStop, limit=activeLongTP)
+if strategy.position_size < 0 and not na(activeShortStop)
+    strategy.exit('Short Exit', 'Short', stop=activeShortStop, limit=activeShortTP)
+
+if strategy.position_size == 0
+    activeLongStop := na
+    activeShortStop := na
+    activeLongTP := na
+    activeShortTP := na
+
+// Forced close at block end, always on.
+if lastBarOfBlock and strategy.position_size != 0
+    strategy.close_all(comment='Block end close', immediately=true)
+    pendingLongStop := na
+    pendingShortStop := na
+
+bgcolor(bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na)
+plot(t3, title='T3', linewidth=2, color=t3Color)
+plot(open6am, title='06:00 Open', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
+plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
+plotshape(newBear, title='Sell Signal', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -2,7 +2,10 @@
 // SZTrades Momentum Alignment Strategy v1.3 (T3 + CVD only)
 // 5m scalping variant with 6:00 open directional bias and 08:00-09:00 execution window.
 
-strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100, use_bar_magnifier=true, calc_on_every_tick=true, process_orders_on_close=false)
+strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true,
+     max_labels_count=500, max_lines_count=500, pyramiding=0,
+     default_qty_type=strategy.percent_of_equity, default_qty_value=100,
+     use_bar_magnifier=true, calc_on_every_tick=true, process_orders_on_close=false)
 
 // Optimization factors
 lengthT3 = input.int(4, 'T3 Length', minval=1, group='T3')
@@ -102,19 +105,12 @@ var float activeShortTP = na
 if longSignal and strategy.position_size == 0
     strategy.entry('Long', strategy.long, comment='Buy signal')
     enteredThisBlock := true
+    activeLongStop := strategy.position_avg_price - stopPoints
+    activeLongTP := strategy.position_avg_price + stopPoints * takeProfitMultiplier
 
 if shortSignal and strategy.position_size == 0
     strategy.entry('Short', strategy.short, comment='Sell signal')
     enteredThisBlock := true
-
-newLongPosition = strategy.position_size > 0 and strategy.position_size[1] <= 0
-newShortPosition = strategy.position_size < 0 and strategy.position_size[1] >= 0
-
-if newLongPosition
-    activeLongStop := strategy.position_avg_price - stopPoints
-    activeLongTP := strategy.position_avg_price + stopPoints * takeProfitMultiplier
-
-if newShortPosition
     activeShortStop := strategy.position_avg_price + stopPoints
     activeShortTP := strategy.position_avg_price - stopPoints * takeProfitMultiplier
 

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -5,8 +5,8 @@
 strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true,
      max_labels_count=500, max_lines_count=500, pyramiding=0,
      default_qty_type=strategy.percent_of_equity, default_qty_value=100,
-     use_bar_magnifier=true, calc_on_every_tick=true, process_orders_on_close=false,
-     commission_type=strategy.commission.percent, commission_value=0.01, slippage=1)
+     use_bar_magnifier=true, calc_on_every_tick=false, process_orders_on_close=true,
+     commission_type=strategy.commission.percent, commission_value=0.01)
 
 // Optimization factors
 lengthT3 = input.int(4, 'T3 Length', minval=1, group='T3')
@@ -15,10 +15,11 @@ cumulationLength = input.int(16, 'CVD Cumulation Length', minval=1, group='CVD')
 cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, group='CVD')
 stopPoints = input.float(4.0, 'Stop Points', minval=0.0, group='Risk')
 takeProfitMultiplier = input.float(2.0, 'Take Profit Multiplier', minval=0.1, group='Risk')
+slippageTicks = input.int(1, 'Slippage (ticks)', minval=0, group='Risk')
 
 // Session controls
 tradeSession = input.session('0800-0900', 'Trading Window (HHMM-HHMM)', group='Session')
-sessionTimezone = 'Etc/GMT+4'
+sessionTimezone = input.string("Etc/GMT+4", "Timezone", group='Session')
 
 gdT3(src, len) =>
     ta.ema(src, len) * (1 + factorT3) - ta.ema(ta.ema(src, len), len) * factorT3
@@ -118,19 +119,22 @@ if shortSignal and not orderPlaced and strategy.position_size == 0
 
 newLong = strategy.position_size > 0 and strategy.position_size[1] == 0
 newShort = strategy.position_size < 0 and strategy.position_size[1] == 0
+newPositionOpened = strategy.position_size != 0 and strategy.position_size[1] == 0
+stopBuffer = slippageTicks * syminfo.mintick
+
+if newPositionOpened
+    enteredThisBlock := true
 
 if newLong and na(activeLongStop)
     entryPrice = strategy.position_avg_price
-    activeLongStop := entryPrice - stopPoints
+    activeLongStop := entryPrice - stopPoints - stopBuffer
     activeLongTP := entryPrice + stopPoints * takeProfitMultiplier
-    enteredThisBlock := true
     strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
 
 if newShort and na(activeShortStop)
     entryPrice = strategy.position_avg_price
-    activeShortStop := entryPrice + stopPoints
+    activeShortStop := entryPrice + stopPoints + stopBuffer
     activeShortTP := entryPrice - stopPoints * takeProfitMultiplier
-    enteredThisBlock := true
     strategy.exit("Short Exit", "Short", stop=activeShortStop, limit=activeShortTP)
 
 if strategy.position_size == 0

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -65,6 +65,7 @@ newBear = bearAligned and not bearAligned[1] and barstate.isconfirmed
 // Session state
 inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
 inPreSession = not na(time(timeframe.period, "0600-0800", sessionTimezone))
+preSession = not na(time(timeframe.period, '0600-0759', sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
 isNewDay = ta.change(time("D")) != 0
@@ -76,6 +77,8 @@ var bool sweptHigh = false
 var bool sweptLow = false
 var bool reclaimedLong = false
 var bool reclaimedShort = false
+var bool preAlignedBull = false
+var bool preAlignedBear = false
 
 if isNewDay
     open6am := na
@@ -89,11 +92,17 @@ if isNewDay
 if inPreSession
     preHigh := na(preHigh) ? high : math.max(preHigh, high)
     preLow := na(preLow) ? low : math.min(preLow, low)
+if preSession and bullAligned
+    preAlignedBull := true
+if preSession and bearAligned
+    preAlignedBear := true
 if blockStarted
     sweptHigh := false
     sweptLow := false
     reclaimedLong := false
     reclaimedShort := false
+    preAlignedBull := false
+    preAlignedBear := false
 
 sweepHigh = not na(preHigh) and high > preHigh and close < preHigh
 sweepLow = not na(preLow) and low < preLow and close > preLow
@@ -169,6 +178,10 @@ showSixOpenLine = not na(time(timeframe.period, '0600-1000', sessionTimezone))
 
 allowLongBySixOpen = not na(open6am) and close > open6am
 allowShortBySixOpen = not na(open6am) and close < open6am
+pullbackLong = close < t3
+pullbackShort = close > t3
+reclaimBull = bullAligned and pullbackLong[1]
+reclaimBear = bearAligned and pullbackShort[1]
 
 // Only execute on 5-minute charts.
 isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
@@ -183,23 +196,12 @@ if blockEnded
     enteredThisBlock := false
     orderPlaced := false
 
-longSignal =
-    isFiveMinuteChart and
-    inTradeBlock and
-    not enteredThisBlock and
-    triggerLong and
-    allowLongBySixOpen and
-    validTimingLong and
-    validPreSession
-
-shortSignal =
-    isFiveMinuteChart and
-    inTradeBlock and
-    not enteredThisBlock and
-    triggerShort and
-    allowShortBySixOpen and
-    validTimingShort and
-    validPreSession
+longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and preAlignedBull and reclaimBull and allowLongBySixOpen
+shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and preAlignedBear and reclaimBear and allowShortBySixOpen
+tooFarLong = close > t3 * 1.002
+tooFarShort = close < t3 * 0.998
+longSignal := longSignal and not tooFarLong
+shortSignal := shortSignal and not tooFarShort
 longSignal := longSignal and barstate.isconfirmed
 shortSignal := shortSignal and barstate.isconfirmed
 

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -5,7 +5,7 @@
 strategy('SZTrades Momentum Alignment Strategy v1.3', shorttitle='SZT1.3', overlay=true,
      max_labels_count=500, max_lines_count=500, pyramiding=0,
      default_qty_type=strategy.percent_of_equity, default_qty_value=100,
-     use_bar_magnifier=true, calc_on_every_tick=false, process_orders_on_close=true,
+     calc_on_every_tick=false, process_orders_on_close=true,
      commission_type=strategy.commission.percent, commission_value=0.01)
 
 // Optimization factors

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -76,6 +76,7 @@ isSixAMBar = hour(time, sessionTimezone) == 6 and minute(time, sessionTimezone) 
 var float open6am = na
 if isSixAMBar
     open6am := open
+showSixOpenLine = not na(time(timeframe.period, '0600-1000', sessionTimezone))
 
 allowLongBySixOpen = not na(open6am) and close > open6am
 allowShortBySixOpen = not na(open6am) and close < open6am
@@ -150,6 +151,6 @@ if lastBarOfBlock and strategy.position_size != 0
 
 bgcolor(bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na)
 plot(t3, title='T3', linewidth=2, color=t3Color)
-plot(open6am, title='06:00 Open', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
+plot(showSixOpenLine ? open6am : na, title='06:00 Open', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
 plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
 plotshape(newBear, title='Sell Signal', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -67,49 +67,82 @@ inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
 inPreSession = not na(time(timeframe.period, "0600-0800", sessionTimezone))
 blockStarted = inTradeBlock and not inTradeBlock[1]
 blockEnded = not inTradeBlock and inTradeBlock[1]
+isNewDay = ta.change(time("D")) != 0
 
+var float open6am = na
 var float preHigh = na
 var float preLow = na
+var bool sweptHigh = false
+var bool sweptLow = false
+var bool reclaimedLong = false
+var bool reclaimedShort = false
+
+if isNewDay
+    open6am := na
+    preHigh := na
+    preLow := na
+    sweptHigh := false
+    sweptLow := false
+    reclaimedLong := false
+    reclaimedShort := false
+
 if inPreSession
     preHigh := na(preHigh) ? high : math.max(preHigh, high)
     preLow := na(preLow) ? low : math.min(preLow, low)
 if blockStarted
-    preHigh := na
-    preLow := na
+    sweptHigh := false
+    sweptLow := false
+    reclaimedLong := false
+    reclaimedShort := false
 
-sweepHigh = high > preHigh and close < preHigh
-sweepLow = low < preLow and close > preLow
-
-var bool sweptHigh = false
-var bool sweptLow = false
+sweepHigh = not na(preHigh) and high > preHigh and close < preHigh
+sweepLow = not na(preLow) and low < preLow and close > preLow
 if sweepHigh
     sweptHigh := true
 if sweepLow
     sweptLow := true
-if blockStarted
-    sweptHigh := false
-    sweptLow := false
 
 reclaimLong = sweptLow and close > preLow
 reclaimShort = sweptHigh and close < preHigh
 
-var bool reclaimedLong = false
-var bool reclaimedShort = false
 if reclaimLong
     reclaimedLong := true
 if reclaimShort
     reclaimedShort := true
-if blockStarted
-    reclaimedLong := false
-    reclaimedShort := false
 
 atrLen = 14
 atr = ta.atr(atrLen)
 preRange = preHigh - preLow
-isCompressed = preRange < atr
+validPreSession = not na(preHigh) and not na(preLow)
+isCompressed = validPreSession and preRange < atr
 isExpanding = (high - low) > atr
-validExpansionLong = isCompressed and isExpanding
-validExpansionShort = isCompressed and isExpanding
+validBullSignal = newBull and reclaimedLong
+validBearSignal = newBear and reclaimedShort
+
+// 1. Sweep already occurred.
+hasSweepLong = sweptLow
+hasSweepShort = sweptHigh
+
+// 2. Reclaim.
+hasReclaimLong = reclaimedLong
+hasReclaimShort = reclaimedShort
+
+// 3. Pullback.
+hasPullbackLong = hasReclaimLong and low <= t3
+hasPullbackShort = hasReclaimShort and high >= t3
+
+// 4. Expansion.
+hasExpansion = isCompressed and isExpanding
+
+barsSinceSweepLow = ta.barssince(sweepLow)
+barsSinceSweepHigh = ta.barssince(sweepHigh)
+validTimingLong = barsSinceSweepLow > 1
+validTimingShort = barsSinceSweepHigh > 1
+strongBody = math.abs(close - open) > (high - low) * 0.6
+
+// 5. Final trigger.
+triggerLong = hasSweepLong and hasPullbackLong and hasExpansion and validBullSignal and strongBody
+triggerShort = hasSweepShort and hasPullbackShort and hasExpansion and validBearSignal and strongBody
 
 // Parse session end time defensively.
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
@@ -130,17 +163,12 @@ lastBarOfBlock = hasValidEnd ? lastBarOfBlockByClock : blockEnded
 
 // Directional bias from 06:00 open (same timezone).
 isSixAMBar = hour(time, sessionTimezone) == 6 and minute(time, sessionTimezone) == 0
-var float open6am = na
 if isSixAMBar
     open6am := open
 showSixOpenLine = not na(time(timeframe.period, '0600-1000', sessionTimezone))
 
 allowLongBySixOpen = not na(open6am) and close > open6am
 allowShortBySixOpen = not na(open6am) and close < open6am
-pullbackLong = reclaimedLong and low <= t3
-pullbackShort = reclaimedShort and high >= t3
-triggerLong = pullbackLong and newBull
-triggerShort = pullbackShort and newBear
 
 // Only execute on 5-minute charts.
 isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
@@ -161,7 +189,8 @@ longSignal =
     not enteredThisBlock and
     triggerLong and
     allowLongBySixOpen and
-    validExpansionLong
+    validTimingLong and
+    validPreSession
 
 shortSignal =
     isFiveMinuteChart and
@@ -169,7 +198,8 @@ shortSignal =
     not enteredThisBlock and
     triggerShort and
     allowShortBySixOpen and
-    validExpansionShort
+    validTimingShort and
+    validPreSession
 longSignal := longSignal and barstate.isconfirmed
 shortSignal := shortSignal and barstate.isconfirmed
 

--- a/SZTrades_Momentum_Strategy_1_3.pine
+++ b/SZTrades_Momentum_Strategy_1_3.pine
@@ -112,15 +112,11 @@ newShortPosition = strategy.position_size < 0 and strategy.position_size[1] >= 0
 
 if newLongPosition
     activeLongStop := strategy.position_avg_price - stopPoints
-    activeShortStop := na
     activeLongTP := strategy.position_avg_price + stopPoints * takeProfitMultiplier
-    activeShortTP := na
 
 if newShortPosition
     activeShortStop := strategy.position_avg_price + stopPoints
-    activeLongStop := na
     activeShortTP := strategy.position_avg_price - stopPoints * takeProfitMultiplier
-    activeLongTP := na
 
 if strategy.position_size > 0 and not na(activeLongStop)
     strategy.exit('Long Exit', 'Long', stop=activeLongStop, limit=activeLongTP)

--- a/SZTrades_Momentum_Strategy_1_4.pine
+++ b/SZTrades_Momentum_Strategy_1_4.pine
@@ -1,0 +1,162 @@
+//@version=6
+// SZTrades Momentum Alignment Strategy v1.4 (T3 + CVD only)
+// 5m scalping variant with 06:00 reference and daily-open directional bias.
+
+strategy('SZTrades Momentum Alignment Strategy v1.4', shorttitle='SZT1.4', overlay=true, max_labels_count=500, max_lines_count=500, pyramiding=0, default_qty_type=strategy.percent_of_equity, default_qty_value=100)
+
+// Optimization factors
+lengthT3 = input.int(4, 'T3 Length', minval=1, group='T3')
+factorT3 = input.float(0.7, 'T3 Factor', minval=0.0, maxval=1.0, group='T3')
+cumulationLength = input.int(16, 'CVD Cumulation Length', minval=1, group='CVD')
+cvdThreshold = input.float(0.0, 'CVD Delta Threshold', minval=0.0, group='CVD')
+stopPoints = input.float(4.0, 'Stop Points', minval=0.0, group='Risk')
+takeProfitMultiplier = input.float(2.0, 'Take Profit Multiplier', minval=0.1, group='Risk')
+
+// Session controls
+tradeSession = input.session('0800-0900', 'Trading Window (HHMM-HHMM)', group='Session')
+sessionTimezone = 'Etc/GMT+4'
+
+gdT3(src, len) =>
+    ta.ema(src, len) * (1 + factorT3) - ta.ema(ta.ema(src, len), len) * factorT3
+
+// T3 core
+t3 = gdT3(gdT3(gdT3(close, lengthT3), lengthT3), lengthT3)
+t3Direction = t3 > t3[1] ? 1 : t3 < t3[1] ? -1 : 0
+t3Color = t3Direction > 0 ? color.green : color.red
+basicLongT3 = t3Direction > 0 and close > t3
+basicShortT3 = t3Direction < 0 and close < t3
+
+// CVD core
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpper = upperWick / spread
+percentLower = lowerWick / spread
+percentBody = bodyLength / spread
+halfWicks = (percentUpper + percentLower) / 2
+buyingVolume = close > open ? (percentBody + halfWicks) * volume : halfWicks * volume
+sellingVolume = close < open ? (percentBody + halfWicks) * volume : halfWicks * volume
+cumBuy = ta.ema(buyingVolume, cumulationLength)
+cumSell = ta.ema(sellingVolume, cumulationLength)
+cvdDelta = cumBuy - cumSell
+bullCVD = cvdDelta > cvdThreshold
+bearCVD = cvdDelta < -cvdThreshold
+
+// Buy/sell signals only when T3 and CVD are aligned.
+bullAligned = basicLongT3 and bullCVD
+bearAligned = basicShortT3 and bearCVD
+newBull = bullAligned and not bullAligned[1]
+newBear = bearAligned and not bearAligned[1]
+
+// Session state
+inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
+blockStarted = inTradeBlock and not inTradeBlock[1]
+blockEnded = not inTradeBlock and inTradeBlock[1]
+
+// Parse session end time defensively.
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ''
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ''
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidEnd = str.length(endTokenClean) >= 4
+endHourRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+sessionEndHour = (hasValidEnd and not na(endHourRaw)) ? int(endHourRaw) : 0
+sessionEndMinute = (hasValidEnd and not na(endMinuteRaw)) ? int(endMinuteRaw) : 0
+sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
+lastBarOfBlockByClock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
+lastBarOfBlock = hasValidEnd ? lastBarOfBlockByClock : blockEnded
+
+// Reference line from 06:00 open (same timezone), visible only in the 06:00-10:00 block.
+isSixAMBar = hour(time, sessionTimezone) == 6 and minute(time, sessionTimezone) == 0
+var float open6am = na
+if isSixAMBar
+    open6am := open
+showSixOpenLine = not na(time(timeframe.period, '0600-1000', sessionTimezone))
+
+// Daily bias from daily open anchored at 18:00 (UTC-4), visible all day.
+isDailyAnchorBar = hour(time, sessionTimezone) == 18 and minute(time, sessionTimezone) == 0
+var float dailyOpen1800 = na
+if isDailyAnchorBar
+    dailyOpen1800 := open
+allowLongByDailyOpen = not na(dailyOpen1800) and close > dailyOpen1800
+allowShortByDailyOpen = not na(dailyOpen1800) and close < dailyOpen1800
+
+// Only execute on 5-minute charts.
+isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
+
+// Only first fresh signal inside each block. No re-entry until close.
+var bool enteredThisBlock = false
+if blockStarted
+    enteredThisBlock := false
+if blockEnded
+    enteredThisBlock := false
+
+longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBull and allowLongByDailyOpen
+shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBear and allowShortByDailyOpen
+longStopFromSignal = low - stopPoints
+shortStopFromSignal = high + stopPoints
+
+var float pendingLongStop = na
+var float pendingShortStop = na
+var float activeLongStop = na
+var float activeShortStop = na
+var float activeLongTP = na
+var float activeShortTP = na
+
+if longSignal and strategy.position_size == 0
+    pendingLongStop := longStopFromSignal
+    pendingShortStop := na
+    strategy.entry('Long', strategy.long, comment='Buy signal')
+    enteredThisBlock := true
+
+if shortSignal and strategy.position_size == 0
+    pendingShortStop := shortStopFromSignal
+    pendingLongStop := na
+    strategy.entry('Short', strategy.short, comment='Sell signal')
+    enteredThisBlock := true
+
+newLongPosition = strategy.position_size > 0 and strategy.position_size[1] <= 0
+newShortPosition = strategy.position_size < 0 and strategy.position_size[1] >= 0
+
+if newLongPosition
+    activeLongStop := pendingLongStop
+    activeShortStop := na
+    longRisk = strategy.position_avg_price - activeLongStop
+    activeLongTP := longRisk > 0 ? strategy.position_avg_price + longRisk * takeProfitMultiplier : na
+    activeShortTP := na
+
+if newShortPosition
+    activeShortStop := pendingShortStop
+    activeLongStop := na
+    shortRisk = activeShortStop - strategy.position_avg_price
+    activeShortTP := shortRisk > 0 ? strategy.position_avg_price - shortRisk * takeProfitMultiplier : na
+    activeLongTP := na
+
+if strategy.position_size > 0 and not na(activeLongStop)
+    strategy.exit('Long Exit', 'Long', stop=activeLongStop, limit=activeLongTP)
+if strategy.position_size < 0 and not na(activeShortStop)
+    strategy.exit('Short Exit', 'Short', stop=activeShortStop, limit=activeShortTP)
+
+if strategy.position_size == 0
+    activeLongStop := na
+    activeShortStop := na
+    activeLongTP := na
+    activeShortTP := na
+
+// Forced close at block end, always on.
+if lastBarOfBlock and strategy.position_size != 0
+    strategy.close_all(comment='Block end close', immediately=true)
+    pendingLongStop := na
+    pendingShortStop := na
+
+bgcolor(bullAligned ? color.new(color.green, 85) : bearAligned ? color.new(color.red, 85) : na)
+plot(t3, title='T3', linewidth=2, color=t3Color)
+plot(showSixOpenLine ? open6am : na, title='06:00 Open', color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
+plot(dailyOpen1800, title='Daily Open 18:00', color=color.new(color.aqua, 0), linewidth=2, style=plot.style_linebr)
+plotshape(newBull, title='Buy Signal', location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
+plotshape(newBear, title='Sell Signal', location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)

--- a/SZTrades_Momentum_Strategy_1_4_SNIPER.pine
+++ b/SZTrades_Momentum_Strategy_1_4_SNIPER.pine
@@ -1,0 +1,270 @@
+//@version=6
+// SZTrades Momentum Alignment Strategy v1.4 SNIPER
+// Layered-filter variant built on the existing T3 + CVD core.
+
+strategy(
+    "SZTrades Momentum Alignment Strategy v1.4 SNIPER",
+    shorttitle="SZT1.4S",
+    overlay=true,
+    pyramiding=0,
+    default_qty_type=strategy.percent_of_equity,
+    default_qty_value=100,
+    calc_on_every_tick=false,
+    process_orders_on_close=true,
+    commission_type=strategy.commission.percent,
+    commission_value=0.01,
+    slippage=1
+)
+
+// ---------------------------------------------------------------------------
+// Base optimization inputs
+// ---------------------------------------------------------------------------
+lengthT3 = input.int(4, "T3 Length", minval=1, group="Base - T3")
+factorT3 = input.float(0.7, "T3 Factor", minval=0.0, maxval=1.0, group="Base - T3")
+cumulationLength = input.int(16, "CVD Cumulation Length", minval=1, group="Base - CVD")
+baseCvdThreshold = input.float(0.0, "Base CVD Threshold", minval=0.0, group="Base - CVD")
+
+stopPoints = input.float(4.0, "Stop Points", minval=0.0, group="Risk")
+takeProfitMultiplier = input.float(2.0, "Take Profit Multiplier", minval=0.1, group="Risk")
+slippageTicks = input.int(1, "Slippage Ticks", minval=0, group="Risk")
+
+tradeSession = input.session("0800-0900", "Trading Window (HHMM-HHMM)", group="Session")
+sessionTimezone = input.string("Etc/GMT+4", "Timezone", group="Session")
+
+// ---------------------------------------------------------------------------
+// SNIPER filter inputs
+// ---------------------------------------------------------------------------
+htfTrendTf = input.timeframe("15", "HTF Trend Timeframe", group="Sniper - HTF Trend")
+htfEmaLen = input.int(200, "HTF EMA Length", minval=1, group="Sniper - HTF Trend")
+
+regimeMode = input.string("ADX + EMA Slope", "Regime Mode", options=["ADX", "EMA Slope", "ADX + EMA Slope"], group="Sniper - Regime")
+adxLen = input.int(14, "ADX Length", minval=1, group="Sniper - Regime")
+adxThreshold = input.float(20.0, "ADX Threshold", minval=1.0, group="Sniper - Regime")
+regimeEmaLen = input.int(50, "Regime EMA Length", minval=1, group="Sniper - Regime")
+regimeSlopeBars = input.int(5, "Regime Slope Bars", minval=1, group="Sniper - Regime")
+regimeSlopeMin = input.float(0.0, "Regime Slope Min", step=0.01, group="Sniper - Regime")
+
+atrLen = input.int(14, "ATR Length", minval=1, group="Sniper - Volatility")
+atrMaLen = input.int(20, "ATR MA Length", minval=1, group="Sniper - Volatility")
+atrMinThreshold = input.float(0.0, "ATR Min Threshold", minval=0.0, group="Sniper - Volatility")
+
+sweepLookback = input.int(15, "Sweep Lookback", minval=2, group="Sniper - Liquidity")
+bodyRatioMin = input.float(0.55, "Min Body Ratio", minval=0.1, maxval=1.0, step=0.01, group="Sniper - Execution Quality")
+
+// ---------------------------------------------------------------------------
+// Helper / core functions
+// ---------------------------------------------------------------------------
+gdT3(src, len) =>
+    ta.ema(src, len) * (1 + factorT3) - ta.ema(ta.ema(src, len), len) * factorT3
+
+// ---------------------------------------------------------------------------
+// Base core logic (kept intact)
+// ---------------------------------------------------------------------------
+t3 = gdT3(gdT3(gdT3(close, lengthT3), lengthT3), lengthT3)
+t3Direction = t3 > t3[1] ? 1 : t3 < t3[1] ? -1 : 0
+t3Color = t3Direction > 0 ? color.green : color.red
+basicLongT3 = t3Direction > 0 and close > t3
+basicShortT3 = t3Direction < 0 and close < t3
+
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpper = upperWick / spread
+percentLower = lowerWick / spread
+percentBody = bodyLength / spread
+halfWicks = (percentUpper + percentLower) / 2
+buyingVolume = close > open ? (percentBody + halfWicks) * volume : halfWicks * volume
+sellingVolume = close < open ? (percentBody + halfWicks) * volume : halfWicks * volume
+cumBuy = ta.ema(buyingVolume, cumulationLength)
+cumSell = ta.ema(sellingVolume, cumulationLength)
+cvdDelta = cumBuy - cumSell
+bullCVD = cvdDelta > baseCvdThreshold
+bearCVD = cvdDelta < -baseCvdThreshold
+
+bullAligned = basicLongT3 and bullCVD
+bearAligned = basicShortT3 and bearCVD
+newBull = bullAligned and not bullAligned[1] and barstate.isconfirmed
+newBear = bearAligned and not bearAligned[1] and barstate.isconfirmed
+
+// ---------------------------------------------------------------------------
+// Session + 06:00 bias + one-trade-per-block
+// ---------------------------------------------------------------------------
+inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
+blockStarted = inTradeBlock and not inTradeBlock[1]
+blockEnded = not inTradeBlock and inTradeBlock[1]
+
+isSixAMBar = hour(time, sessionTimezone) == 6 and minute(time, sessionTimezone) == 0
+var float open6am = na
+if isSixAMBar
+    open6am := open
+if ta.change(time("D")) != 0
+    open6am := na
+
+allowLongBySixOpen = not na(open6am) and close > open6am
+allowShortBySixOpen = not na(open6am) and close < open6am
+
+// Parse session end time defensively for force-close logic.
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ""
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ""
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidEnd = str.length(endTokenClean) >= 4
+endHourRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+sessionEndHour = (hasValidEnd and not na(endHourRaw)) ? int(endHourRaw) : 0
+sessionEndMinute = (hasValidEnd and not na(endMinuteRaw)) ? int(endMinuteRaw) : 0
+sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
+lastBarOfBlockByClock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
+lastBarOfBlock = hasValidEnd ? lastBarOfBlockByClock : blockEnded
+
+// ---------------------------------------------------------------------------
+// SNIPER layered filters
+// ---------------------------------------------------------------------------
+// 1) HTF trend filter (EMA200)
+htfEma = request.security(syminfo.tickerid, htfTrendTf, ta.ema(close, htfEmaLen), lookahead=barmerge.lookahead_off)
+htfLongOk = close > htfEma
+htfShortOk = close < htfEma
+
+// 2) Regime filter (ADX and/or EMA slope)
+adxValue = ta.adx(adxLen)
+adxOk = adxValue > adxThreshold
+regimeEma = ta.ema(close, regimeEmaLen)
+regimeSlope = regimeEma - regimeEma[regimeSlopeBars]
+slopeLongOk = regimeSlope > regimeSlopeMin
+slopeShortOk = regimeSlope < -regimeSlopeMin
+
+regimeLongOk = regimeMode == "ADX" ? adxOk : regimeMode == "EMA Slope" ? slopeLongOk : adxOk and slopeLongOk
+regimeShortOk = regimeMode == "ADX" ? adxOk : regimeMode == "EMA Slope" ? slopeShortOk : adxOk and slopeShortOk
+
+// 3) ATR volatility filter
+atrValue = ta.atr(atrLen)
+atrMA = ta.sma(atrValue, atrMaLen)
+validVolatility = atrValue > atrMA and atrValue > atrMinThreshold
+
+// 4) Liquidity sweep filter (simple form)
+var bool longSweepSeen = false
+var bool shortSweepSeen = false
+if blockStarted
+    longSweepSeen := false
+    shortSweepSeen := false
+
+if inTradeBlock and low < ta.lowest(low[1], sweepLookback)
+    longSweepSeen := true
+if inTradeBlock and high > ta.highest(high[1], sweepLookback)
+    shortSweepSeen := true
+
+// 5) Execution quality filter (body/wick quality)
+bodyRatio = math.abs(close - open) / math.max(high - low, syminfo.mintick)
+qualityOk = bodyRatio >= bodyRatioMin
+
+// ---------------------------------------------------------------------------
+// Final SNIPER signals
+// ---------------------------------------------------------------------------
+isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
+baseLongSignal = isFiveMinuteChart and inTradeBlock and newBull and allowLongBySixOpen
+baseShortSignal = isFiveMinuteChart and inTradeBlock and newBear and allowShortBySixOpen
+
+longSignal = baseLongSignal and htfLongOk and regimeLongOk and validVolatility and longSweepSeen and qualityOk
+shortSignal = baseShortSignal and htfShortOk and regimeShortOk and validVolatility and shortSweepSeen and qualityOk
+
+// ---------------------------------------------------------------------------
+// Order / position management (base behavior preserved)
+// ---------------------------------------------------------------------------
+var bool enteredThisBlock = false
+var bool orderPlaced = false
+if blockStarted
+    enteredThisBlock := false
+    orderPlaced := false
+if blockEnded
+    enteredThisBlock := false
+    orderPlaced := false
+
+var float activeLongStop = na
+var float activeShortStop = na
+var float activeLongTP = na
+var float activeShortTP = na
+
+if longSignal and not enteredThisBlock and not orderPlaced and strategy.position_size == 0
+    strategy.entry("Long", strategy.long)
+    orderPlaced := true
+
+if shortSignal and not enteredThisBlock and not orderPlaced and strategy.position_size == 0
+    strategy.entry("Short", strategy.short)
+    orderPlaced := true
+
+newLong = strategy.position_size > 0 and strategy.position_size[1] == 0
+newShort = strategy.position_size < 0 and strategy.position_size[1] == 0
+newPositionOpened = strategy.position_size != 0 and strategy.position_size[1] == 0
+stopBuffer = slippageTicks * syminfo.mintick
+
+if newPositionOpened
+    enteredThisBlock := true
+
+if newLong and na(activeLongStop)
+    entryPrice = strategy.position_avg_price
+    activeLongStop := entryPrice - stopPoints - stopBuffer
+    activeLongTP := entryPrice + stopPoints * takeProfitMultiplier
+    strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
+
+if newShort and na(activeShortStop)
+    entryPrice = strategy.position_avg_price
+    activeShortStop := entryPrice + stopPoints + stopBuffer
+    activeShortTP := entryPrice - stopPoints * takeProfitMultiplier
+    strategy.exit("Short Exit", "Short", stop=activeShortStop, limit=activeShortTP)
+
+if strategy.position_size == 0
+    activeLongStop := na
+    activeShortStop := na
+    activeLongTP := na
+    activeShortTP := na
+
+if lastBarOfBlock and strategy.position_size != 0
+    strategy.close_all(comment="Block end close")
+
+// ---------------------------------------------------------------------------
+// Visuals
+// ---------------------------------------------------------------------------
+bgcolor(bullAligned ? color.new(color.green, 88) : bearAligned ? color.new(color.red, 88) : na)
+plot(t3, title="T3", linewidth=2, color=t3Color)
+plot(open6am, title="06:00 Open", color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
+plot(htfEma, title="HTF EMA200", color=color.new(color.purple, 0), linewidth=1)
+
+plotshape(newBull, title="Bull Alignment", location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
+plotshape(newBear, title="Bear Alignment", location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)
+
+// ---------------------------------------------------------------------------
+// Metrics table (real-time)
+// ---------------------------------------------------------------------------
+var table stats = table.new(position.top_right, 2, 7, border_width=1)
+if barstate.islast
+    closedTrades = strategy.closedtrades
+    winRate = closedTrades > 0 ? (strategy.wintrades * 100.0) / closedTrades : na
+    profitFactor = strategy.grossloss != 0 ? strategy.grossprofit / math.abs(strategy.grossloss) : na
+    avgTrade = closedTrades > 0 ? strategy.netprofit / closedTrades : na
+    maxDrawdown = strategy.max_drawdown
+    netProfit = strategy.netprofit
+
+    table.cell(stats, 0, 0, "Total trades", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 0, str.tostring(closedTrades), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 1, "Win rate %", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 1, str.tostring(winRate, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 2, "Profit factor", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 2, str.tostring(profitFactor, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 3, "Avg trade", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 3, str.tostring(avgTrade, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 4, "Max drawdown", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 4, str.tostring(maxDrawdown, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 5, "Net profit", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 5, str.tostring(netProfit, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 6, "Regime", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 6, regimeMode, text_color=color.white, bgcolor=color.new(color.black, 0))

--- a/SZTrades_Momentum_Strategy_1_4_SNIPER.pine
+++ b/SZTrades_Momentum_Strategy_1_4_SNIPER.pine
@@ -130,7 +130,7 @@ htfLongOk = close > htfEma
 htfShortOk = close < htfEma
 
 // 2) Regime filter (ADX and/or EMA slope)
-adxValue = ta.adx(adxLen)
+[_, _, adxValue] = ta.dmi(adxLen, adxLen)
 adxOk = adxValue > adxThreshold
 regimeEma = ta.ema(close, regimeEmaLen)
 regimeSlope = regimeEma - regimeEma[regimeSlopeBars]
@@ -152,9 +152,12 @@ if blockStarted
     longSweepSeen := false
     shortSweepSeen := false
 
-if inTradeBlock and low < ta.lowest(low[1], sweepLookback)
+sweepLowRef = ta.lowest(low, sweepLookback)[1]
+sweepHighRef = ta.highest(high, sweepLookback)[1]
+
+if inTradeBlock and low < sweepLowRef
     longSweepSeen := true
-if inTradeBlock and high > ta.highest(high[1], sweepLookback)
+if inTradeBlock and high > sweepHighRef
     shortSweepSeen := true
 
 // 5) Execution quality filter (body/wick quality)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replaced unsupported `ta.adx(...)` usage with Pine v6-compatible ADX from `ta.dmi(...)`
- moved liquidity sweep references to per-bar global series variables:
  - `sweepLowRef = ta.lowest(low, sweepLookback)[1]`
  - `sweepHighRef = ta.highest(high, sweepLookback)[1]`
- updated sweep checks to use those variables, removing inconsistent conditional-history calls

## Why
This resolves the reported compile errors/warnings:
- `Could not find function or function reference 'ta.adx'`
- conditional `ta.lowest()` / `ta.highest()` historical consistency warnings

## Validation
- verified the diff only touches `SZTrades_Momentum_Strategy_1_4_SNIPER.pine`
- no strategy logic changes beyond compatibility/consistency fixes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96b5081f-dff4-4fec-899e-b6b2d5ee4920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96b5081f-dff4-4fec-899e-b6b2d5ee4920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

