### PR TITLE
Add v1.5 XAUUSD sniper strategy with lightweight anti-noise filters

### DIFF
--- a/SZTrades_Momentum_Strategy_1_5_1_XAUUSD_HARDENED.pine
+++ b/SZTrades_Momentum_Strategy_1_5_1_XAUUSD_HARDENED.pine
@@ -1,0 +1,337 @@
+//@version=6
+// SZTrades Momentum Alignment Strategy v1.5.1 HARDENED (XAUUSD Sniper Scalper)
+// Base T3 + CVD logic preserved. Hardened filters layered on top.
+
+strategy(
+    "SZTrades Momentum Alignment Strategy v1.5.1 HARDENED (XAUUSD Sniper Scalper)",
+    shorttitle="SZT1.5H",
+    overlay=true,
+    pyramiding=0,
+    default_qty_type=strategy.percent_of_equity,
+    default_qty_value=100,
+    calc_on_every_tick=false,
+    process_orders_on_close=true,
+    commission_type=strategy.commission.percent,
+    commission_value=0.01,
+    slippage=1
+)
+
+// ---------------------------------------------------------------------------
+// Base optimization inputs
+// ---------------------------------------------------------------------------
+lengthT3 = input.int(4, "T3 Length", minval=1, group="Base - T3")
+factorT3 = input.float(0.7, "T3 Factor", minval=0.0, maxval=1.0, group="Base - T3")
+cumulationLength = input.int(16, "CVD Cumulation Length", minval=1, group="Base - CVD")
+baseCvdThreshold = input.float(0.0, "Base CVD Threshold", minval=0.0, group="Base - CVD")
+
+stopPoints = input.float(4.0, "Stop Points", minval=0.0, group="Risk")
+takeProfitMultiplier = input.float(2.0, "Take Profit Multiplier", minval=0.1, group="Risk")
+slippageTicks = input.int(1, "Slippage Ticks", minval=0, group="Risk")
+
+tradeSession = input.session("0800-0900", "Trading Window (HHMM-HHMM)", group="Session")
+sessionTimezone = input.string("Etc/GMT+4", "Timezone", group="Session")
+
+// ---------------------------------------------------------------------------
+// v1.5 base lightweight filters
+// ---------------------------------------------------------------------------
+rangeFastLen = input.int(20, "Range Fast Length", minval=2, group="Sniper - Volatility")
+rangeSlowLen = input.int(60, "Range Slow Length", minval=5, group="Sniper - Volatility")
+rangeExpansionMin = input.float(0.9, "Range Expansion Min", minval=0.1, step=0.05, group="Sniper - Volatility")
+
+bodyRatioMin = input.float(0.65, "Min Body Ratio", minval=0.1, maxval=1.0, step=0.01, group="Sniper - Execution Quality")
+trendEmaLen = input.int(50, "Trend EMA Length", minval=1, group="Sniper - Trend")
+narrowBarsLen = input.int(5, "Narrow Bars Window", minval=2, group="Sniper - Liquidity Clean")
+narrowRangeFactor = input.float(0.65, "Narrow Range Factor", minval=0.1, maxval=1.0, step=0.05, group="Sniper - Liquidity Clean")
+cooldownBars = input.int(4, "Cooldown Bars Between Trades", minval=0, group="Sniper - Frequency")
+
+// ---------------------------------------------------------------------------
+// v1.5.1 HARDENED filters
+// ---------------------------------------------------------------------------
+regimeAtrLen = input.int(14, "Regime ATR Length", minval=1, group="Hardened - Regime")
+regimeAtrMaLen = input.int(20, "Regime ATR MA Length", minval=1, group="Hardened - Regime")
+regimeSlopeBars = input.int(5, "Regime EMA Slope Bars", minval=1, group="Hardened - Regime")
+breakoutRangeMult = input.float(1.05, "Breakout Range Mult", minval=0.5, step=0.05, group="Hardened - Regime")
+
+chopAtrRatioMin = input.float(0.9, "Chop ATR Ratio Min", minval=0.1, step=0.05, group="Hardened - Chop Killer")
+chopBodyAvgLen = input.int(10, "Chop Body Avg Length", minval=2, group="Hardened - Chop Killer")
+chopBodyAvgMax = input.float(0.5, "Chop Body Avg Max", minval=0.1, maxval=1.0, step=0.01, group="Hardened - Chop Killer")
+
+confirmBreakLookback = input.int(3, "Entry Break Lookback", minval=2, group="Hardened - Entry Tightening")
+dominantWickRatio = input.float(0.6, "Dominant Wick Ratio", minval=0.1, maxval=1.0, step=0.05, group="Hardened - Liquidity Clean")
+
+// ---------------------------------------------------------------------------
+// Helper / core functions
+// ---------------------------------------------------------------------------
+gdT3(src, len) =>
+    ta.ema(src, len) * (1 + factorT3) - ta.ema(ta.ema(src, len), len) * factorT3
+
+// ---------------------------------------------------------------------------
+// Base core logic (kept intact)
+// ---------------------------------------------------------------------------
+t3 = gdT3(gdT3(gdT3(close, lengthT3), lengthT3), lengthT3)
+t3Direction = t3 > t3[1] ? 1 : t3 < t3[1] ? -1 : 0
+t3Color = t3Direction > 0 ? color.green : color.red
+basicLongT3 = t3Direction > 0 and close > t3
+basicShortT3 = t3Direction < 0 and close < t3
+
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpper = upperWick / spread
+percentLower = lowerWick / spread
+percentBody = bodyLength / spread
+halfWicks = (percentUpper + percentLower) / 2
+buyingVolume = close > open ? (percentBody + halfWicks) * volume : halfWicks * volume
+sellingVolume = close < open ? (percentBody + halfWicks) * volume : halfWicks * volume
+cumBuy = ta.ema(buyingVolume, cumulationLength)
+cumSell = ta.ema(sellingVolume, cumulationLength)
+cvdDelta = cumBuy - cumSell
+bullCVD = cvdDelta > baseCvdThreshold
+bearCVD = cvdDelta < -baseCvdThreshold
+
+bullAligned = basicLongT3 and bullCVD
+bearAligned = basicShortT3 and bearCVD
+newBull = bullAligned and not bullAligned[1] and barstate.isconfirmed
+newBear = bearAligned and not bearAligned[1] and barstate.isconfirmed
+
+// ---------------------------------------------------------------------------
+// Session + 06:00 bias + one-trade-per-block
+// ---------------------------------------------------------------------------
+inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
+blockStarted = inTradeBlock and not inTradeBlock[1]
+blockEnded = not inTradeBlock and inTradeBlock[1]
+
+isSixAMBar = hour(time, sessionTimezone) == 6 and minute(time, sessionTimezone) == 0
+var float open6am = na
+if isSixAMBar
+    open6am := open
+if ta.change(time("D")) != 0
+    open6am := na
+
+allowLongBySixOpen = not na(open6am) and close > open6am
+allowShortBySixOpen = not na(open6am) and close < open6am
+
+// Parse session end time defensively for force-close logic.
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ""
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ""
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidEnd = str.length(endTokenClean) >= 4
+endHourRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+sessionEndHour = hasValidEnd and not na(endHourRaw) ? int(endHourRaw) : 0
+sessionEndMinute = hasValidEnd and not na(endMinuteRaw) ? int(endMinuteRaw) : 0
+sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
+lastBarOfBlockByClock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
+lastBarOfBlock = hasValidEnd ? lastBarOfBlockByClock : blockEnded
+
+// ---------------------------------------------------------------------------
+// v1.5 base lightweight filter stack
+// ---------------------------------------------------------------------------
+barRange = math.max(high - low, syminfo.mintick)
+avgRecentRange = ta.sma(barRange, rangeFastLen)
+avgBaselineRange = ta.sma(barRange, rangeSlowLen)
+volatilityRegimeOk = not na(avgRecentRange) and not na(avgBaselineRange) and avgRecentRange >= avgBaselineRange * rangeExpansionMin
+
+bodyRatio = math.abs(close - open) / barRange
+executionQualityOk = bodyRatio >= bodyRatioMin
+
+trendEma = ta.ema(close, trendEmaLen)
+trendLongOk = close > trendEma
+trendShortOk = close < trendEma
+
+effectiveRangeBaseline = na(avgBaselineRange) ? barRange : avgBaselineRange
+narrowBar = barRange <= effectiveRangeBaseline * narrowRangeFactor
+narrowBarCount = ta.sma(narrowBar ? 1.0 : 0.0, narrowBarsLen) * narrowBarsLen
+liquidityCleanOk = not na(avgBaselineRange) and not na(narrowBarCount) and narrowBarCount < narrowBarsLen
+
+// ---------------------------------------------------------------------------
+// v1.5.1 HARDENED gate stack
+// ---------------------------------------------------------------------------
+regimeAtr = ta.atr(regimeAtrLen)
+regimeAtrMa = ta.sma(regimeAtr, regimeAtrMaLen)
+atrAboveAvg = not na(regimeAtrMa) and regimeAtr > regimeAtrMa
+atrRising = regimeAtr > regimeAtr[1]
+trendSlope = trendEma - trendEma[regimeSlopeBars]
+slopeLongAligned = trendSlope > 0
+slopeShortAligned = trendSlope < 0
+
+trendExpansionLong = atrAboveAvg and atrRising and slopeLongAligned
+trendExpansionShort = atrAboveAvg and atrRising and slopeShortAligned
+breakoutRangeExpansion = volatilityRegimeOk and not na(avgRecentRange) and barRange >= avgRecentRange * breakoutRangeMult
+breakoutRegimeLong = breakoutRangeExpansion and slopeLongAligned
+breakoutRegimeShort = breakoutRangeExpansion and slopeShortAligned
+regimeLongOk = trendExpansionLong or breakoutRegimeLong
+regimeShortOk = trendExpansionShort or breakoutRegimeShort
+
+atrRatio = not na(regimeAtrMa) and regimeAtrMa > 0 ? regimeAtr / regimeAtrMa : 0.0
+bodyRatioAvg = ta.sma(bodyRatio, chopBodyAvgLen)
+isDeadChop = atrRatio < chopAtrRatioMin and bodyRatioAvg < chopBodyAvgMax
+chopKillerOk = not isDeadChop
+
+breakConfirmLong = high > ta.highest(high, confirmBreakLookback)[1]
+breakConfirmShort = low < ta.lowest(low, confirmBreakLookback)[1]
+
+wickLongOk = upperWick <= barRange * dominantWickRatio
+wickShortOk = lowerWick <= barRange * dominantWickRatio
+
+volatilityScoreLong = (volatilityRegimeOk and regimeLongOk and chopKillerOk) ? 1 : 0
+volatilityScoreShort = (volatilityRegimeOk and regimeShortOk and chopKillerOk) ? 1 : 0
+trendScoreLong = trendLongOk ? 1 : 0
+trendScoreShort = trendShortOk ? 1 : 0
+bodyScore = executionQualityOk ? 1 : 0
+executionScoreLong = trendScoreLong + volatilityScoreLong + bodyScore
+executionScoreShort = trendScoreShort + volatilityScoreShort + bodyScore
+executionScoreLongOk = executionScoreLong == 3
+executionScoreShortOk = executionScoreShort == 3
+
+// ---------------------------------------------------------------------------
+// Final v1.5.1 hardened signals
+// ---------------------------------------------------------------------------
+isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
+
+var bool enteredThisBlock = false
+var bool orderPlaced = false
+var int lastTradeBarIndex = na
+
+cooldownOk = cooldownBars == 0 or na(lastTradeBarIndex) or (bar_index - lastTradeBarIndex) >= cooldownBars
+
+baseLongSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBull and allowLongBySixOpen
+baseShortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBear and allowShortBySixOpen
+
+longSignal = baseLongSignal and trendLongOk and volatilityRegimeOk and executionQualityOk and liquidityCleanOk and regimeLongOk and chopKillerOk and breakConfirmLong and wickLongOk and executionScoreLongOk and cooldownOk
+shortSignal = baseShortSignal and trendShortOk and volatilityRegimeOk and executionQualityOk and liquidityCleanOk and regimeShortOk and chopKillerOk and breakConfirmShort and wickShortOk and executionScoreShortOk and cooldownOk
+
+// ---------------------------------------------------------------------------
+// Order / position management (base behavior preserved)
+// ---------------------------------------------------------------------------
+if blockStarted
+    enteredThisBlock := false
+    orderPlaced := false
+if blockEnded
+    enteredThisBlock := false
+    orderPlaced := false
+
+closedTradeNow = strategy.closedtrades > nz(strategy.closedtrades[1], 0)
+tradePnlDelta = strategy.netprofit - nz(strategy.netprofit[1], strategy.netprofit)
+if closedTradeNow and tradePnlDelta < 0
+    lastTradeBarIndex := na
+
+var float activeLongStop = na
+var float activeShortStop = na
+var float activeLongTP = na
+var float activeShortTP = na
+
+if longSignal and not enteredThisBlock and not orderPlaced and strategy.position_size == 0
+    strategy.entry("Long", strategy.long)
+    orderPlaced := true
+
+if shortSignal and not enteredThisBlock and not orderPlaced and strategy.position_size == 0
+    strategy.entry("Short", strategy.short)
+    orderPlaced := true
+
+newLong = strategy.position_size > 0 and strategy.position_size[1] == 0
+newShort = strategy.position_size < 0 and strategy.position_size[1] == 0
+newPositionOpened = strategy.position_size != 0 and strategy.position_size[1] == 0
+stopBuffer = slippageTicks * syminfo.mintick
+
+if newPositionOpened
+    enteredThisBlock := true
+    lastTradeBarIndex := bar_index
+
+if newLong and na(activeLongStop)
+    entryPrice = strategy.position_avg_price
+    activeLongStop := entryPrice - stopPoints - stopBuffer
+    activeLongTP := entryPrice + stopPoints * takeProfitMultiplier
+    strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
+
+if newShort and na(activeShortStop)
+    entryPrice = strategy.position_avg_price
+    activeShortStop := entryPrice + stopPoints + stopBuffer
+    activeShortTP := entryPrice - stopPoints * takeProfitMultiplier
+    strategy.exit("Short Exit", "Short", stop=activeShortStop, limit=activeShortTP)
+
+if strategy.position_size == 0
+    activeLongStop := na
+    activeShortStop := na
+    activeLongTP := na
+    activeShortTP := na
+
+if lastBarOfBlock and strategy.position_size != 0
+    strategy.close_all(comment="Block end close")
+
+// ---------------------------------------------------------------------------
+// Visuals
+// ---------------------------------------------------------------------------
+bgcolor(bullAligned ? color.new(color.green, 88) : bearAligned ? color.new(color.red, 88) : na)
+plot(t3, title="T3", linewidth=2, color=t3Color)
+plot(open6am, title="06:00 Open", color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
+plot(trendEma, title="Trend EMA 50", color=color.new(color.aqua, 0), linewidth=1)
+
+plotshape(newBull, title="Bull Alignment", location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
+plotshape(newBear, title="Bear Alignment", location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)
+
+// ---------------------------------------------------------------------------
+// Metrics table (real-time, enhanced)
+// ---------------------------------------------------------------------------
+var int firstBarTime = na
+if barstate.isfirst
+    firstBarTime := time
+
+var table stats = table.new(position.top_right, 2, 10, border_width=1)
+if barstate.islast
+    closedTrades = strategy.closedtrades
+    winRate = closedTrades > 0 ? (strategy.wintrades * 100.0) / closedTrades : na
+    profitFactor = strategy.grossloss != 0 ? strategy.grossprofit / math.abs(strategy.grossloss) : na
+    avgTrade = closedTrades > 0 ? strategy.netprofit / closedTrades : na
+    maxDrawdown = strategy.max_drawdown
+    netProfit = strategy.netprofit
+    expectancy = stopPoints > 0 and not na(avgTrade) ? avgTrade / stopPoints : na
+
+    elapsedDays = not na(firstBarTime) ? math.max((time - firstBarTime) / 86400000.0, 1.0) : 1.0
+    tradesPerDay = closedTrades / elapsedDays
+
+    int maxWinStreak = 0
+    int curWinStreak = 0
+    for i = 0 to 499
+        if i < closedTrades
+            tradeProfit = strategy.closedtrades.profit(i)
+            if tradeProfit > 0
+                curWinStreak += 1
+                maxWinStreak := math.max(maxWinStreak, curWinStreak)
+            else
+                curWinStreak := 0
+
+    table.cell(stats, 0, 0, "Total trades", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 0, str.tostring(closedTrades), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 1, "Win rate %", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 1, str.tostring(winRate, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 2, "Profit factor", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 2, str.tostring(profitFactor, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 3, "Avg trade", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 3, str.tostring(avgTrade, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 4, "Max drawdown", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 4, str.tostring(maxDrawdown, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 5, "Net profit", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 5, str.tostring(netProfit, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 6, "Expectancy", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 6, str.tostring(expectancy, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 7, "Max win streak", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 7, str.tostring(maxWinStreak), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 8, "Trades/day", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 8, str.tostring(tradesPerDay, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 9, "Mode", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 9, "v1.5.1 HARDENED", text_color=color.white, bgcolor=color.new(color.black, 0))

--- a/SZTrades_Momentum_Strategy_1_5_XAUUSD_SNIPER.pine
+++ b/SZTrades_Momentum_Strategy_1_5_XAUUSD_SNIPER.pine
@@ -1,0 +1,248 @@
+//@version=6
+// SZTrades Momentum Alignment Strategy v1.5 (XAUUSD Sniper Scalper)
+// Base T3 + CVD logic preserved. Added lightweight robustness filters.
+
+strategy(
+    "SZTrades Momentum Alignment Strategy v1.5 (XAUUSD Sniper Scalper)",
+    shorttitle="SZT1.5X",
+    overlay=true,
+    pyramiding=0,
+    default_qty_type=strategy.percent_of_equity,
+    default_qty_value=100,
+    calc_on_every_tick=false,
+    process_orders_on_close=true,
+    commission_type=strategy.commission.percent,
+    commission_value=0.01,
+    slippage=1
+)
+
+// ---------------------------------------------------------------------------
+// Base optimization inputs
+// ---------------------------------------------------------------------------
+lengthT3 = input.int(4, "T3 Length", minval=1, group="Base - T3")
+factorT3 = input.float(0.7, "T3 Factor", minval=0.0, maxval=1.0, group="Base - T3")
+cumulationLength = input.int(16, "CVD Cumulation Length", minval=1, group="Base - CVD")
+baseCvdThreshold = input.float(0.0, "Base CVD Threshold", minval=0.0, group="Base - CVD")
+
+stopPoints = input.float(4.0, "Stop Points", minval=0.0, group="Risk")
+takeProfitMultiplier = input.float(2.0, "Take Profit Multiplier", minval=0.1, group="Risk")
+slippageTicks = input.int(1, "Slippage Ticks", minval=0, group="Risk")
+
+tradeSession = input.session("0800-0900", "Trading Window (HHMM-HHMM)", group="Session")
+sessionTimezone = input.string("Etc/GMT+4", "Timezone", group="Session")
+
+// ---------------------------------------------------------------------------
+// v1.5 lightweight sniper filters
+// ---------------------------------------------------------------------------
+rangeFastLen = input.int(20, "Range Fast Length", minval=2, group="Sniper - Volatility")
+rangeSlowLen = input.int(60, "Range Slow Length", minval=5, group="Sniper - Volatility")
+rangeExpansionMin = input.float(0.9, "Range Expansion Min", minval=0.1, step=0.05, group="Sniper - Volatility")
+
+bodyRatioMin = input.float(0.65, "Min Body Ratio", minval=0.1, maxval=1.0, step=0.01, group="Sniper - Execution Quality")
+
+trendEmaLen = input.int(50, "Trend EMA Length", minval=1, group="Sniper - Trend")
+
+narrowBarsLen = input.int(5, "Narrow Bars Window", minval=2, group="Sniper - Liquidity Clean")
+narrowRangeFactor = input.float(0.65, "Narrow Range Factor", minval=0.1, maxval=1.0, step=0.05, group="Sniper - Liquidity Clean")
+
+cooldownBars = input.int(4, "Cooldown Bars Between Trades", minval=0, group="Sniper - Frequency")
+
+// ---------------------------------------------------------------------------
+// Helper / core functions
+// ---------------------------------------------------------------------------
+gdT3(src, len) =>
+    ta.ema(src, len) * (1 + factorT3) - ta.ema(ta.ema(src, len), len) * factorT3
+
+// ---------------------------------------------------------------------------
+// Base core logic (kept intact)
+// ---------------------------------------------------------------------------
+t3 = gdT3(gdT3(gdT3(close, lengthT3), lengthT3), lengthT3)
+t3Direction = t3 > t3[1] ? 1 : t3 < t3[1] ? -1 : 0
+t3Color = t3Direction > 0 ? color.green : color.red
+basicLongT3 = t3Direction > 0 and close > t3
+basicShortT3 = t3Direction < 0 and close < t3
+
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpper = upperWick / spread
+percentLower = lowerWick / spread
+percentBody = bodyLength / spread
+halfWicks = (percentUpper + percentLower) / 2
+buyingVolume = close > open ? (percentBody + halfWicks) * volume : halfWicks * volume
+sellingVolume = close < open ? (percentBody + halfWicks) * volume : halfWicks * volume
+cumBuy = ta.ema(buyingVolume, cumulationLength)
+cumSell = ta.ema(sellingVolume, cumulationLength)
+cvdDelta = cumBuy - cumSell
+bullCVD = cvdDelta > baseCvdThreshold
+bearCVD = cvdDelta < -baseCvdThreshold
+
+bullAligned = basicLongT3 and bullCVD
+bearAligned = basicShortT3 and bearCVD
+newBull = bullAligned and not bullAligned[1] and barstate.isconfirmed
+newBear = bearAligned and not bearAligned[1] and barstate.isconfirmed
+
+// ---------------------------------------------------------------------------
+// Session + 06:00 bias + one-trade-per-block
+// ---------------------------------------------------------------------------
+inTradeBlock = not na(time(timeframe.period, tradeSession, sessionTimezone))
+blockStarted = inTradeBlock and not inTradeBlock[1]
+blockEnded = not inTradeBlock and inTradeBlock[1]
+
+isSixAMBar = hour(time, sessionTimezone) == 6 and minute(time, sessionTimezone) == 0
+var float open6am = na
+if isSixAMBar
+    open6am := open
+if ta.change(time("D")) != 0
+    open6am := na
+
+allowLongBySixOpen = not na(open6am) and close > open6am
+allowShortBySixOpen = not na(open6am) and close < open6am
+
+// Parse session end time defensively for force-close logic.
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ""
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ""
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidEnd = str.length(endTokenClean) >= 4
+endHourRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+sessionEndHour = hasValidEnd and not na(endHourRaw) ? int(endHourRaw) : 0
+sessionEndMinute = hasValidEnd and not na(endMinuteRaw) ? int(endMinuteRaw) : 0
+sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+barCloseMinuteOfDay = hour(time_close, sessionTimezone) * 60 + minute(time_close, sessionTimezone)
+lastBarOfBlockByClock = inTradeBlock and barCloseMinuteOfDay == sessionEndMinuteOfDay
+lastBarOfBlock = hasValidEnd ? lastBarOfBlockByClock : blockEnded
+
+// ---------------------------------------------------------------------------
+// v1.5 lightweight filter stack
+// ---------------------------------------------------------------------------
+barRange = math.max(high - low, syminfo.mintick)
+avgRecentRange = ta.sma(barRange, rangeFastLen)
+avgBaselineRange = ta.sma(barRange, rangeSlowLen)
+volatilityRegimeOk = not na(avgRecentRange) and not na(avgBaselineRange) and avgRecentRange >= avgBaselineRange * rangeExpansionMin
+
+bodyRatio = math.abs(close - open) / barRange
+executionQualityOk = bodyRatio >= bodyRatioMin
+
+trendEma = ta.ema(close, trendEmaLen)
+trendLongOk = close > trendEma
+trendShortOk = close < trendEma
+
+effectiveRangeBaseline = na(avgBaselineRange) ? barRange : avgBaselineRange
+narrowBar = barRange <= effectiveRangeBaseline * narrowRangeFactor
+narrowBarCount = ta.sum(narrowBar ? 1.0 : 0.0, narrowBarsLen)
+liquidityCleanOk = not na(avgBaselineRange) and narrowBarCount < narrowBarsLen
+
+// ---------------------------------------------------------------------------
+// Final v1.5 sniper signals
+// ---------------------------------------------------------------------------
+isFiveMinuteChart = timeframe.isminutes and timeframe.multiplier == 5
+
+var bool enteredThisBlock = false
+var bool orderPlaced = false
+var int lastTradeBarIndex = na
+cooldownOk = cooldownBars == 0 or na(lastTradeBarIndex) or (bar_index - lastTradeBarIndex) >= cooldownBars
+
+longSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBull and allowLongBySixOpen and volatilityRegimeOk and trendLongOk and executionQualityOk and liquidityCleanOk and cooldownOk
+shortSignal = isFiveMinuteChart and inTradeBlock and not enteredThisBlock and newBear and allowShortBySixOpen and volatilityRegimeOk and trendShortOk and executionQualityOk and liquidityCleanOk and cooldownOk
+
+// ---------------------------------------------------------------------------
+// Order / position management (base behavior preserved)
+// ---------------------------------------------------------------------------
+if blockStarted
+    enteredThisBlock := false
+    orderPlaced := false
+if blockEnded
+    enteredThisBlock := false
+    orderPlaced := false
+
+var float activeLongStop = na
+var float activeShortStop = na
+var float activeLongTP = na
+var float activeShortTP = na
+
+if longSignal and not enteredThisBlock and not orderPlaced and strategy.position_size == 0
+    strategy.entry("Long", strategy.long)
+    orderPlaced := true
+
+if shortSignal and not enteredThisBlock and not orderPlaced and strategy.position_size == 0
+    strategy.entry("Short", strategy.short)
+    orderPlaced := true
+
+newLong = strategy.position_size > 0 and strategy.position_size[1] == 0
+newShort = strategy.position_size < 0 and strategy.position_size[1] == 0
+newPositionOpened = strategy.position_size != 0 and strategy.position_size[1] == 0
+stopBuffer = slippageTicks * syminfo.mintick
+
+if newPositionOpened
+    enteredThisBlock := true
+    lastTradeBarIndex := bar_index
+
+if newLong and na(activeLongStop)
+    entryPrice = strategy.position_avg_price
+    activeLongStop := entryPrice - stopPoints - stopBuffer
+    activeLongTP := entryPrice + stopPoints * takeProfitMultiplier
+    strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
+
+if newShort and na(activeShortStop)
+    entryPrice = strategy.position_avg_price
+    activeShortStop := entryPrice + stopPoints + stopBuffer
+    activeShortTP := entryPrice - stopPoints * takeProfitMultiplier
+    strategy.exit("Short Exit", "Short", stop=activeShortStop, limit=activeShortTP)
+
+if strategy.position_size == 0
+    activeLongStop := na
+    activeShortStop := na
+    activeLongTP := na
+    activeShortTP := na
+
+if lastBarOfBlock and strategy.position_size != 0
+    strategy.close_all(comment="Block end close")
+
+// ---------------------------------------------------------------------------
+// Visuals
+// ---------------------------------------------------------------------------
+bgcolor(bullAligned ? color.new(color.green, 88) : bearAligned ? color.new(color.red, 88) : na)
+plot(t3, title="T3", linewidth=2, color=t3Color)
+plot(open6am, title="06:00 Open", color=color.new(color.yellow, 0), linewidth=2, style=plot.style_linebr)
+plot(trendEma, title="Trend EMA 50", color=color.new(color.aqua, 0), linewidth=1)
+
+plotshape(newBull, title="Bull Alignment", location=location.belowbar, style=shape.triangleup, color=color.new(color.green, 0), size=size.tiny)
+plotshape(newBear, title="Bear Alignment", location=location.abovebar, style=shape.triangledown, color=color.new(color.red, 0), size=size.tiny)
+
+// ---------------------------------------------------------------------------
+// Metrics table (real-time)
+// ---------------------------------------------------------------------------
+var table stats = table.new(position.top_right, 2, 7, border_width=1)
+if barstate.islast
+    closedTrades = strategy.closedtrades
+    winRate = closedTrades > 0 ? (strategy.wintrades * 100.0) / closedTrades : na
+    profitFactor = strategy.grossloss != 0 ? strategy.grossprofit / math.abs(strategy.grossloss) : na
+    avgTrade = closedTrades > 0 ? strategy.netprofit / closedTrades : na
+    maxDrawdown = strategy.max_drawdown
+    netProfit = strategy.netprofit
+
+    table.cell(stats, 0, 0, "Total trades", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 0, str.tostring(closedTrades), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 1, "Win rate %", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 1, str.tostring(winRate, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 2, "Profit factor", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 2, str.tostring(profitFactor, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 3, "Avg trade", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 3, str.tostring(avgTrade, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 4, "Max drawdown", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 4, str.tostring(maxDrawdown, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 5, "Net profit", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 5, str.tostring(netProfit, "#.##"), text_color=color.white, bgcolor=color.new(color.black, 0))
+
+    table.cell(stats, 0, 6, "Mode", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(stats, 1, 6, "v1.5 XAU Sniper", text_color=color.white, bgcolor=color.new(color.black, 0))

--- a/SZTrades_Momentum_Strategy_1_5_XAUUSD_SNIPER.pine
+++ b/SZTrades_Momentum_Strategy_1_5_XAUUSD_SNIPER.pine
@@ -134,8 +134,8 @@ trendShortOk = close < trendEma
 
 effectiveRangeBaseline = na(avgBaselineRange) ? barRange : avgBaselineRange
 narrowBar = barRange <= effectiveRangeBaseline * narrowRangeFactor
-narrowBarCount = math.sum(narrowBar ? 1.0 : 0.0, narrowBarsLen)
-liquidityCleanOk = not na(avgBaselineRange) and narrowBarCount < narrowBarsLen
+narrowBarCount = ta.sma(narrowBar ? 1.0 : 0.0, narrowBarsLen) * narrowBarsLen
+liquidityCleanOk = not na(avgBaselineRange) and not na(narrowBarCount) and narrowBarCount < narrowBarsLen
 
 // ---------------------------------------------------------------------------
 // Final v1.5 sniper signals

--- a/SZTrades_Momentum_Strategy_1_5_XAUUSD_SNIPER.pine
+++ b/SZTrades_Momentum_Strategy_1_5_XAUUSD_SNIPER.pine
@@ -134,7 +134,7 @@ trendShortOk = close < trendEma
 
 effectiveRangeBaseline = na(avgBaselineRange) ? barRange : avgBaselineRange
 narrowBar = barRange <= effectiveRangeBaseline * narrowRangeFactor
-narrowBarCount = ta.sum(narrowBar ? 1.0 : 0.0, narrowBarsLen)
+narrowBarCount = math.sum(narrowBar ? 1.0 : 0.0, narrowBarsLen)
 liquidityCleanOk = not na(avgBaselineRange) and narrowBarCount < narrowBarsLen
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This branch now includes two strategy files:
- `SZTrades_Momentum_Strategy_1_5_XAUUSD_SNIPER.pine` (v1.5)
- `SZTrades_Momentum_Strategy_1_5_1_XAUUSD_HARDENED.pine` (v1.5.1 HARDENED)

## v1.5 (existing in this branch)
- Lightweight anti-noise filter stack for XAUUSD 5m:
  - range-based volatility regime filter
  - stricter execution quality (body/range)
  - EMA50 trend alignment (same timeframe)
  - narrow-range liquidity clean filter
  - optional cooldown bars between trades

## v1.5.1 HARDENED (new)
Built from v1.5 while preserving base T3+CVD/session/06:00 bias and stop/TP model.

Added hardened layers:
- strict regime gate:
  - trend expansion path (ATR > ATR MA, ATR rising, EMA slope aligned)
  - breakout regime path (range expansion + EMA slope aligned)
- chop killer:
  - no trade when ATR ratio is weak and average body ratio is low
- entry tightening confirmation break:
  - long requires break above recent 3-bar high
  - short requires break below recent 3-bar low
- liquidity clean wick dominance guard:
  - blocks longs on dominant upper wick
  - blocks shorts on dominant lower wick
- execution score (0..3):
  - +1 trend
  - +1 volatility/regime
  - +1 body quality
  - requires score == 3
- improved cooldown behavior:
  - cooldown can reset after a losing close
- enhanced metrics table:
  - expectancy (avg trade / risk)
  - max win streak
  - trades per day (approx)

## Compatibility hardening
- No use of unavailable sum functions (`ta.sum`/`math.sum`).
- Narrow-bar counting uses SMA-based equivalent.

## Constraints respected
- Base T3 + CVD model untouched
- Session structure and 06:00 bias untouched
- Stop/TP logic untouched
- No HTF EMA200/ADX-heavy architecture added
- Pine v6 format and bar-close execution retained
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96b5081f-dff4-4fec-899e-b6b2d5ee4920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96b5081f-dff4-4fec-899e-b6b2d5ee4920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

