### PR TITLE
feat: editable background colors + stabilized 2h trigger logic

### DIFF
--- a/SZT_CVD_with_Threshold_base.pine
+++ b/SZT_CVD_with_Threshold_base.pine
@@ -1,0 +1,34 @@
+//@version=6
+indicator("CVD with Threshold", overlay=false)
+
+// Inputs
+cvdLength = input.int(14, "CVD Length")
+threshold = input.float(0, "CVD Threshold (abs value)", step=10)
+
+// Cálculo del delta (igual que Ankit)
+upper_wick = close > open ? high - close : high - open
+lower_wick = close > open ? open - low : close - low
+spread = high - low
+body_length = spread - (upper_wick + lower_wick)
+
+percent_upper_wick = upper_wick / spread
+percent_lower_wick = lower_wick / spread
+percent_body_length = body_length / spread
+
+buying_volume = close > open ? (percent_body_length + (percent_upper_wick + percent_lower_wick)/2) * volume : ((percent_upper_wick + percent_lower_wick)/2) * volume
+selling_volume = close < open ? (percent_body_length + (percent_upper_wick + percent_lower_wick)/2) * volume : ((percent_upper_wick + percent_lower_wick)/2) * volume
+
+cumulative_buying_volume = ta.ema(buying_volume, cvdLength)
+cumulative_selling_volume = ta.ema(selling_volume, cvdLength)
+
+cvdDelta = cumulative_buying_volume - cumulative_selling_volume
+
+// Threshold filtering
+deltaFiltered = math.abs(cvdDelta) > threshold ? cvdDelta : 0
+
+// Colors for columns
+col = cvdDelta > threshold ? color.green : cvdDelta < -threshold ? color.red : color.gray
+
+// Plot
+plot(deltaFiltered, "CVD Delta (filtered)", color=col, style=plot.style_columns, linewidth=2)
+hline(0, "Zero Line", color=color.gray, linestyle=hline.style_dotted)

--- a/SZT_Kernel_JMA_Alignment_base.pine
+++ b/SZT_Kernel_JMA_Alignment_base.pine
@@ -1,0 +1,143 @@
+//@version=6
+indicator("SZTrades Kernel + JMA Alignment", "SZT Align", overlay = true)
+
+import jdehorty/KernelFunctions/2 as kernels
+
+// Kernel Settings
+useKernelSmoothing = input.bool(false, "Enhance Kernel Smoothing", tooltip="If enabled, alignment uses kernel cross (yhat2 vs yhat1). If disabled, uses kernel rate of change.", group='Kernel Settings')
+h = input.int(8, 'Lookback Window', minval=3, tooltip='Bars used for estimation. Recommended: 3-50', group="Kernel Settings")
+r = input.float(8., 'Relative Weighting', step=0.25, tooltip='Relative weighting of time frames. Recommended: 0.25-25', group="Kernel Settings")
+x = input.int(25, "Regression Level", tooltip='Starting bar index for regression. Smaller = tighter fit. Recommended: 2-25', group="Kernel Settings")
+lag = input.int(2, "Lag", tooltip="Lag for crossover detection. Recommended: 1-2", group='Kernel Settings')
+source = input.source(close, "Source", group="Kernel Settings")
+showKernelLine = input.bool(true, "Show Kernel Line", group = "Kernel Settings")
+kernelLineWidth = input.int(1, "Kernel Line Width", minval = 1, maxval = 5, group = "Kernel Settings")
+
+// JMA Settings
+// Hard-coded length = 20
+jmaLength = 20
+jmaPhase = input.int(50, "JMA Phase", minval = -100, maxval = 100, group = "JMA")
+jmaPower = input.int(2, "JMA Power", minval = 1, group = "JMA")
+useJmaColorConfirm = input.bool(true, "Use JMA Color Confirmation", group = "JMA")
+invertJmaSignals = input.bool(false, "Invert JMA Signals", group = "JMA")
+showJmaLine = input.bool(true, "Show JMA Line", group = "JMA")
+jmaLineWidth = input.int(1, "JMA Line Width", minval = 1, maxval = 5, group = "JMA")
+
+// Display
+longColor = input.color(#009988, "Bar Color Long", group="Display")
+shortColor = input.color(#8e8989, "Bar Color Short", group="Display")
+useBarColor = input.bool(true, "Color Bars When Aligned", group="Display")
+barTransp = input.int(50, "Bar Color Transparency", minval=0, maxval=100, group="Display")
+
+// ================================
+// ==== Kernel Regression (Lib) ===
+// ================================
+yhat1 = kernels.rationalQuadratic(source, h, r, x)
+yhat2 = kernels.gaussian(source, h - lag, x)
+
+wasBearishRate = yhat1[2] > yhat1[1]
+wasBullishRate = yhat1[2] < yhat1[1]
+isBearishRate = yhat1[1] > yhat1
+isBullishRate = yhat1[1] < yhat1
+isBullishSmooth = yhat2 >= yhat1
+isBearishSmooth = yhat2 <= yhat1
+
+kernelBullish = useKernelSmoothing ? isBullishSmooth : isBullishRate
+kernelBearish = useKernelSmoothing ? isBearishSmooth : isBearishRate
+
+// Optional Kernel plot (two-color like kernel regression)
+kernelPlotColor = (useKernelSmoothing ? (yhat2 >= yhat1) : (yhat1 > yhat1[1])) ? color.new(#009988, 0) : color.new(#747171, 0)
+plot(showKernelLine ? yhat1 : na, title = "Kernel", color = kernelPlotColor, linewidth = kernelLineWidth)
+
+// ===============
+// ====  JMA  ====
+// ===============
+phaseRatio = jmaPhase < -100 ? 0.5 : jmaPhase > 100 ? 2.5 : jmaPhase / 100 + 1.5
+beta = 0.45 * (jmaLength - 1) / (0.45 * (jmaLength - 1) + 2)
+alpha = math.pow(beta, jmaPower)
+
+var float jma = na
+var float e0 = na
+var float e1 = na
+var float e2 = na
+
+e0 := (1 - alpha) * source + alpha * nz(e0[1])
+e1 := (source - e0) * (1 - beta) + beta * nz(e1[1])
+e2 := (e0 + phaseRatio * e1 - nz(jma[1])) * math.pow(1 - alpha, 2) + math.pow(alpha, 2) * nz(e2[1])
+jma := e2 + nz(jma[1])
+
+// Optional JMA plot (two-color like kernel regression)
+jmaPlotColor = (jma > jma[1]) ? color.new(#009988, 0) : color.new(#959595, 0)
+plot(showJmaLine ? jma : na, title = "JMA", color = jmaPlotColor, linewidth = jmaLineWidth)
+
+isUp = jma > jma[1]
+isDown = jma < jma[1]
+longBase = useJmaColorConfirm ? (isUp and close > jma) : (close > jma)
+shortBase = useJmaColorConfirm ? (isDown and close < jma) : (close < jma)
+jmaLong = invertJmaSignals ? shortBase : longBase
+jmaShort = invertJmaSignals ? longBase : shortBase
+
+// ======================
+// ==== Alignment I/O ===
+// ======================
+alignLong = jmaLong and kernelBullish
+alignShort = jmaShort and kernelBearish
+
+// Start-of-alignment only with cycle gating (non-repainting at bar close)
+var int cycleDir = 0  // 1 = long cycle active, -1 = short cycle active, 0 = none
+alignLongStart = barstate.isconfirmed and alignLong and not alignLong[1] and (cycleDir != 1)
+alignShortStart = barstate.isconfirmed and alignShort and not alignShort[1] and (cycleDir != -1)
+cycleDir := alignLongStart ? 1 : alignShortStart ? -1 : cycleDir
+// Reset cycle when opposite alignment becomes true
+cycleDir := (cycleDir == 1 and alignShort) ? 0 : (cycleDir == -1 and alignLong) ? 0 : cycleDir
+
+// Top-of-chart dots (no labels)
+plotshape(alignLongStart, title='Align Long Start', style=shape.labelup, location=location.belowbar, color=longColor, size=size.tiny, text="")
+plotshape(alignShortStart, title='Align Short Start', style=shape.labeldown, location=location.abovebar, color=shortColor, size=size.tiny, text="")
+
+// Optional: bar coloring while aligned; clears on de-alignment
+barColorSeries = alignLong ? color.new(longColor, barTransp) : alignShort ? color.new(shortColor, barTransp) : na
+barcolor(useBarColor ? barColorSeries : na)
+
+// Heartbeats for adapters (data window)
+
+// Alerts
+alertcondition(alignLongStart, title='Kernel+JMA Align Long (Start)', message='SZT Align Long ▲ | {{ticker}}@{{close}} | ({{interval}})')
+alertcondition(alignShortStart, title='Kernel+JMA Align Short (Start)', message='SZT Align Short ▼ | {{ticker}}@{{close}} | ({{interval}})')
+
+// ============================
+// ==== Volatility Stop (SL) ===
+// ============================
+useVolStop   = input.bool(true,  "Use Volatility Stop", group="Volatility Stop")
+vsLength     = input.int(20,     "Length", minval=2, group="Volatility Stop")
+vsFactor     = input.float(2.0,  "Multiplier", minval=0.25, step=0.25, group="Volatility Stop")
+vsSource     = input.source(close, "Source", group="Volatility Stop")
+vsShowLine   = input.bool(false, "Show Stop Line", group="Volatility Stop")
+vsShowDots   = input.bool(true,  "Show Stop Dots", group="Volatility Stop")
+vsLineWidth  = input.int(1,      "Stop Line Width", minval=1, maxval=5, group="Volatility Stop")
+
+volStop(src, atrlen, atrmult) =>
+    if not na(src)
+        var float regimeMax = src
+        var float regimeMin = src
+        var bool  uptrend   = true
+        var float stop      = na
+        atrM = ta.atr(atrlen) * atrmult
+        regimeMax := math.max(regimeMax, src)
+        regimeMin := math.min(regimeMin, src)
+        stop := nz(uptrend ? math.max(stop, regimeMax - atrM) : math.min(stop, regimeMin + atrM), src)
+        uptrend := src - stop >= 0.0
+        prevUp = (bar_index > 0) ? uptrend[1] : true
+        if uptrend != prevUp
+            regimeMax := src
+            regimeMin := src
+            stop := uptrend ? regimeMax - atrM : regimeMin + atrM
+        [stop, uptrend]
+
+[vsStop, vsUp] = volStop(vsSource, vsLength, vsFactor)
+vsColor = vsUp ? color.new(#09d647, 0) : color.new(#8f8b8a, 0)
+plot(useVolStop and vsShowLine ? vsStop : na, title="Volatility Stop", color=vsColor, linewidth=vsLineWidth)
+plot(useVolStop and vsShowDots ? vsStop : na, title="Volatility Stop Dots", style=plot.style_cross, color=vsColor, linewidth=1)
+
+// Data-window output for SL reference
+plot(useVolStop ? vsStop : na, title="SL Level (VolStop)", display=display.data_window)

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -13,9 +13,12 @@ trigger3Tf = input.timeframe("15", "Trigger 3) Lower Timeframe Candle Reference 
 trigger1Price = request.security(syminfo.tickerid, trigger1Tf, close, barmerge.gaps_off, barmerge.lookahead_off)
 trigger2Price = request.security(syminfo.tickerid, trigger2Tf, close, barmerge.gaps_off, barmerge.lookahead_off)
 trigger3Price = request.security(syminfo.tickerid, trigger3Tf, close, barmerge.gaps_off, barmerge.lookahead_off)
+trigger1Open = request.security(syminfo.tickerid, trigger1Tf, open, barmerge.gaps_off, barmerge.lookahead_off)
 
 priceAboveAllTriggers = close > trigger1Price and close > trigger2Price and close > trigger3Price
 priceBelowAllTriggers = close < trigger1Price and close < trigger2Price and close < trigger3Price
+trigger1LongBias = close > trigger1Open
+trigger1ShortBias = close < trigger1Open
 
 // ============================
 // ==== Kernel Settings =======
@@ -140,8 +143,9 @@ barColorSeries = alignLong ? color.new(bullColor, barTransp) : alignShort ? colo
 barcolor(useBarColor ? barColorSeries : na)
 
 // Confirmed-bar trigger background: only paints on closed candles.
-bgLong = barstate.isconfirmed and useBarColor and alignLong and cvdBullish and priceAboveAllTriggers
-bgShort = barstate.isconfirmed and useBarColor and alignShort and cvdBearish and priceBelowAllTriggers
+// Background follows active alignment and additionally requires Trigger-1 open bias.
+bgLong = barstate.isconfirmed and useBarColor and alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias
+bgShort = barstate.isconfirmed and useBarColor and alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias
 bgColorSeries = bgLong ? color.new(bullColor, bgTransp) : bgShort ? color.new(bearColor, bgTransp) : na
 bgcolor(bgColorSeries, title="Trigger Background")
 

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -174,6 +174,8 @@ vsLineWidth = input.int(1, "Stop Line Width", minval=1, maxval=5, group="Volatil
 // ============================
 useBarColor = input.bool(true, "Color Bars When Aligned", group="Display")
 barTransp = input.int(50, "Bar Color Transparency", minval=0, maxval=100, group="Display")
+bgBullColor = input.color(#009988, "Background Long Color", group="Display")
+bgBearColor = input.color(#8e8989, "Background Short Color", group="Display")
 bgTransp = input.int(86, "Background Transparency", minval=0, maxval=100, group="Display")
 
 bullColor = #009988
@@ -201,7 +203,7 @@ barcolor(useBarColor ? barColorSeries : na)
 // Background follows active alignment and additionally requires Trigger-1 open bias.
 bgLong = barstate.isconfirmed and useBarColor and alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk and cycleDir != -1
 bgShort = barstate.isconfirmed and useBarColor and alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk and cycleDir != 1
-bgColorSeries = bgLong ? color.new(bullColor, bgTransp) : bgShort ? color.new(bearColor, bgTransp) : na
+bgColorSeries = bgLong ? color.new(bgBullColor, bgTransp) : bgShort ? color.new(bgBearColor, bgTransp) : na
 bgcolor(bgColorSeries, title="Trigger Background")
 
 // Alerts

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -16,7 +16,12 @@ showTriggerDebug = input.bool(false, "Show Trigger Debug Table", group="Trigger 
 triggerTimezone = triggerTimezoneMode == "Exchange" ? syminfo.timezone : triggerTimezoneMode == "America/New_York (DST)" ? "America/New_York" : "Etc/GMT+4"
 
 // Build timezone-aligned trigger opens so the 2h/1h/15m references match the selected clock.
-t1 = time(trigger1Tf, "", triggerTimezone)
+// Forzar vela de 2h a comenzar a las 8:00 AM (hora NY / timezone seleccionada).
+var int sessionStartHour = 8
+trigger1DayStart = timestamp(triggerTimezone, year(time, triggerTimezone), month(time, triggerTimezone), dayofmonth(time, triggerTimezone), 0, 0)
+trigger1Anchor = trigger1DayStart + sessionStartHour * 60 * 60 * 1000
+trigger1BucketMs = 2 * 60 * 60 * 1000
+t1 = trigger1Anchor + int(math.floor((time - trigger1Anchor) / trigger1BucketMs)) * trigger1BucketMs
 t2 = time(trigger2Tf, "", triggerTimezone)
 t3 = time(trigger3Tf, "", triggerTimezone)
 

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -9,16 +9,46 @@ import jdehorty/KernelFunctions/2 as kernels
 trigger1Tf = input.timeframe("120", "Trigger 1) Higher Timeframe Candle Reference (2h)", group="Trigger Settings")
 trigger2Tf = input.timeframe("60", "Trigger 2) Medium Timeframe Candle Reference (1h)", group="Trigger Settings")
 trigger3Tf = input.timeframe("15", "Trigger 3) Lower Timeframe Candle Reference (15m)", group="Trigger Settings")
+triggerTimezoneMode = input.string("UTC-4 (fixed)", "Trigger Timezone", options=["UTC-4 (fixed)", "America/New_York (DST)", "Exchange"], tooltip="Controls where 2h/1h/15m trigger candles start. Use UTC-4 fixed or New York DST-aware clock.", group="Trigger Settings")
+showTriggerDebug = input.bool(false, "Show Trigger Debug Table", group="Trigger Settings")
+triggerTimezone = triggerTimezoneMode == "Exchange" ? syminfo.timezone : triggerTimezoneMode == "America/New_York (DST)" ? "America/New_York" : "Etc/GMT+4"
 
-// Use open-based HTF references so trigger checks work on the active HTF candle.
-trigger1Level = request.security(syminfo.tickerid, trigger1Tf, open, barmerge.gaps_off, barmerge.lookahead_off)
-trigger2Level = request.security(syminfo.tickerid, trigger2Tf, open, barmerge.gaps_off, barmerge.lookahead_off)
-trigger3Level = request.security(syminfo.tickerid, trigger3Tf, open, barmerge.gaps_off, barmerge.lookahead_off)
+// Build timezone-aligned trigger opens so the 2h/1h/15m references match the selected clock.
+t1 = time(trigger1Tf, "", triggerTimezone)
+t2 = time(trigger2Tf, "", triggerTimezone)
+t3 = time(trigger3Tf, "", triggerTimezone)
+
+var float trigger1Level = na
+var float trigger2Level = na
+var float trigger3Level = na
+
+trigger1Level := na(t1[1]) or t1 != t1[1] ? open : nz(trigger1Level[1], open)
+trigger2Level := na(t2[1]) or t2 != t2[1] ? open : nz(trigger2Level[1], open)
+trigger3Level := na(t3[1]) or t3 != t3[1] ? open : nz(trigger3Level[1], open)
 
 priceAboveAllTriggers = close > trigger1Level and close > trigger2Level and close > trigger3Level
 priceBelowAllTriggers = close < trigger1Level and close < trigger2Level and close < trigger3Level
 trigger1LongBias = close > trigger1Level
 trigger1ShortBias = close < trigger1Level
+
+if showTriggerDebug and barstate.islast
+    var table dbg = table.new(position.top_right, 2, 8, border_width=1)
+    table.cell(dbg, 0, 0, "TZ", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 1, 0, triggerTimezone, text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 0, 1, "2h start", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 1, 1, str.format_time(t1, "yyyy-MM-dd HH:mm", triggerTimezone), text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 0, 2, "T1 open", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 1, 2, str.tostring(trigger1Level, format.mintick), text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 0, 3, "Close", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 1, 3, str.tostring(close, format.mintick), text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 0, 4, "T1 Long Bias", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 1, 4, str.tostring(trigger1LongBias), text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 0, 5, "T1 Short Bias", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 1, 5, str.tostring(trigger1ShortBias), text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 0, 6, "Above all", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 1, 6, str.tostring(priceAboveAllTriggers), text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 0, 7, "Below all", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 1, 7, str.tostring(priceBelowAllTriggers), text_color=color.white, bgcolor=color.new(color.black, 0))
 
 // ============================
 // ==== Kernel Settings =======

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -34,14 +34,15 @@ trigger1LongBias = close > trigger1Level
 trigger1ShortBias = close < trigger1Level
 var int cycleDir = 0 // 1 = long cycle active, -1 = short cycle active, 0 = none
 
-// --- RESETEO DE CICLO POR TIMEFRAMES SUPERIORES ---
-// Este bloque debe ejecutarse ANTES de calcular bgLong/bgShort
-if na(trigger1Level[1]) or trigger1Level != trigger1Level[1] or na(trigger2Level[1]) or trigger2Level != trigger2Level[1]
-    cycleDir := 0
-
-if (cycleDir == -1 and trigger1LongBias)
-    cycleDir := 0
-if (cycleDir == 1 and trigger1ShortBias)
+// --- RESETEO FORZADO DE CICLO POR BIAS DE 2h ---
+// Si la vela de 2h es alcista, el ciclo DEBE ser alcista.
+// Si la vela de 2h es bajista, el ciclo DEBE ser bajista.
+// Si no hay bias claro (precio igual al open), se resetea a 0.
+if trigger1LongBias
+    cycleDir := 1
+else if trigger1ShortBias
+    cycleDir := -1
+else
     cycleDir := 0
 trigger4AtrAvg = ta.atr(trigger4AtrAvgLen)
 trigger4VolatilityOk = trigger4AtrAvg <= trigger4AtrMax

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -53,17 +53,18 @@ if showTriggerDebug and barstate.islast
 // ============================
 // ==== Kernel Settings =======
 // ============================
-h = 4
-r = 4.0
-x = 10
-lag = 1
+kernel_h = input.int(4, "Kernel Lookback (h)", minval=2, group="Kernel Settings")
+kernel_r = input.float(4.0, "Kernel Relative Weight (r)", step=0.5, group="Kernel Settings")
+kernel_x = input.int(10, "Kernel Regression Level (x)", minval=2, group="Kernel Settings")
+kernel_lag = input.int(1, "Kernel Lag", minval=1, maxval=3, group="Kernel Settings")
 source = close
 kernelLineWidth = input.int(1, "Kernel Line Width", minval=1, maxval=5, group="Kernel Settings")
 kernelBullColor = input.color(#009988, "Kernel Bull Color", group="Kernel Settings")
 kernelBearColor = input.color(#747171, "Kernel Bear Color", group="Kernel Settings")
 
-yhat1 = kernels.rationalQuadratic(source, h, r, x)
-yhat2 = kernels.gaussian(source, h - lag, x)
+yhat1 = kernels.rationalQuadratic(source, kernel_h, kernel_r, kernel_x)
+kernelSmoothLookback = math.max(1, kernel_h - kernel_lag)
+yhat2 = kernels.gaussian(source, kernelSmoothLookback, kernel_x)
 
 // Smoothing is hardcoded ON: alignment uses yhat2 vs yhat1.
 kernelBullish = yhat2 >= yhat1
@@ -76,8 +77,8 @@ plot(yhat1, title="Kernel", color=kernelPlotColor, linewidth=kernelLineWidth)
 // ====== JMA Settings ========
 // ============================
 jmaLength = 20
-jmaPhase = 40
-jmaPower = 2
+jmaPhase = input.int(40, "JMA Phase", minval=-100, maxval=100, group="JMA Settings")
+jmaPower = input.int(2, "JMA Power", minval=1, maxval=5, group="JMA Settings")
 jmaLineWidth = input.int(1, "JMA Line Width", minval=1, maxval=5, group="JMA Settings")
 jmaBullColor = input.color(#009988, "JMA Bull Color", group="JMA Settings")
 jmaBearColor = input.color(#959595, "JMA Bear Color", group="JMA Settings")
@@ -108,8 +109,8 @@ jmaShort = isDown and close < jma
 // ============================
 // ====== CVD Settings ========
 // ============================
-cvdLength = 14
-cvdThreshold = 10.0
+cvdLength = input.int(14, "CVD Length", minval=1, group="CVD Settings")
+cvdThreshold = input.float(10.0, "CVD Threshold", step=5.0, group="CVD Settings")
 
 upperWick = close > open ? high - close : high - open
 lowerWick = close > open ? open - low : close - low
@@ -136,8 +137,8 @@ plot(cvdDelta, title="CVD Delta", display=display.data_window)
 // ==== Volatility Stop (SL) ===
 // ============================
 useVolStop = input.bool(true, "Use Volatility Stop", group="Volatility Stop")
-vsLength = 20
-vsFactor = 2.0
+vsLength = input.int(20, "ATR Length", minval=2, group="Volatility Stop")
+vsFactor = input.float(2.0, "ATR Multiplier", step=0.25, group="Volatility Stop")
 vsSource = close
 vsShowLine = input.bool(false, "Show Stop Line", group="Volatility Stop")
 vsShowDots = input.bool(true, "Show Stop Dots", group="Volatility Stop")

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -1,0 +1,177 @@
+//@version=6
+indicator("SZT Trend align + CVD", "SZT Align + CVD", overlay=true)
+
+import jdehorty/KernelFunctions/2 as kernels
+
+// ==============================
+// ==== Trigger Timeframes ======
+// ==============================
+trigger1Tf = input.timeframe("120", "Trigger 1) Higher Timeframe Candle Reference (2h)", group="Trigger Settings")
+trigger2Tf = input.timeframe("60", "Trigger 2) Medium Timeframe Candle Reference (1h)", group="Trigger Settings")
+trigger3Tf = input.timeframe("15", "Trigger 3) Lower Timeframe Candle Reference (15m)", group="Trigger Settings")
+
+trigger1Price = request.security(syminfo.tickerid, trigger1Tf, close, barmerge.gaps_off, barmerge.lookahead_off)
+trigger2Price = request.security(syminfo.tickerid, trigger2Tf, close, barmerge.gaps_off, barmerge.lookahead_off)
+trigger3Price = request.security(syminfo.tickerid, trigger3Tf, close, barmerge.gaps_off, barmerge.lookahead_off)
+
+priceAboveAllTriggers = close > trigger1Price and close > trigger2Price and close > trigger3Price
+priceBelowAllTriggers = close < trigger1Price and close < trigger2Price and close < trigger3Price
+
+// ============================
+// ==== Kernel Settings =======
+// ============================
+h = input.int(8, "Lookback Window", minval=3, tooltip="Bars used for estimation. Recommended: 3-50", group="Kernel Settings")
+r = input.float(8.0, "Relative Weighting", step=0.25, tooltip="Relative weighting of time frames. Recommended: 0.25-25", group="Kernel Settings")
+x = input.int(25, "Regression Level", tooltip="Starting bar index for regression. Smaller = tighter fit. Recommended: 2-25", group="Kernel Settings")
+lag = input.int(2, "Lag", tooltip="Lag for crossover detection. Recommended: 1-2", group="Kernel Settings")
+source = input.source(close, "Source", group="Kernel Settings")
+kernelLineWidth = input.int(1, "Kernel Line Width", minval=1, maxval=5, group="Kernel Settings")
+kernelBullColor = input.color(#009988, "Kernel Bull Color", group="Kernel Settings")
+kernelBearColor = input.color(#747171, "Kernel Bear Color", group="Kernel Settings")
+
+yhat1 = kernels.rationalQuadratic(source, h, r, x)
+yhat2 = kernels.gaussian(source, h - lag, x)
+
+// Smoothing is hardcoded ON: alignment uses yhat2 vs yhat1.
+kernelBullish = yhat2 >= yhat1
+kernelBearish = yhat2 <= yhat1
+
+kernelPlotColor = kernelBullish ? kernelBullColor : kernelBearColor
+plot(yhat1, title="Kernel", color=kernelPlotColor, linewidth=kernelLineWidth)
+
+// ============================
+// ====== JMA Settings ========
+// ============================
+jmaLength = 20
+jmaPhase = input.int(50, "JMA Phase", minval=-100, maxval=100, group="JMA Settings")
+jmaPower = input.int(2, "JMA Power", minval=1, group="JMA Settings")
+jmaLineWidth = input.int(1, "JMA Line Width", minval=1, maxval=5, group="JMA Settings")
+jmaBullColor = input.color(#009988, "JMA Bull Color", group="JMA Settings")
+jmaBearColor = input.color(#959595, "JMA Bear Color", group="JMA Settings")
+
+phaseRatio = jmaPhase < -100 ? 0.5 : jmaPhase > 100 ? 2.5 : jmaPhase / 100 + 1.5
+beta = 0.45 * (jmaLength - 1) / (0.45 * (jmaLength - 1) + 2)
+alpha = math.pow(beta, jmaPower)
+
+var float jma = na
+var float e0 = na
+var float e1 = na
+var float e2 = na
+
+e0 := (1 - alpha) * source + alpha * nz(e0[1])
+e1 := (source - e0) * (1 - beta) + beta * nz(e1[1])
+e2 := (e0 + phaseRatio * e1 - nz(jma[1])) * math.pow(1 - alpha, 2) + math.pow(alpha, 2) * nz(e2[1])
+jma := e2 + nz(jma[1])
+
+jmaPlotColor = jma > jma[1] ? jmaBullColor : jmaBearColor
+plot(jma, title="JMA", color=jmaPlotColor, linewidth=jmaLineWidth)
+
+// JMA color confirmation is hardcoded ON.
+isUp = jma > jma[1]
+isDown = jma < jma[1]
+jmaLong = isUp and close > jma
+jmaShort = isDown and close < jma
+
+// ============================
+// ====== CVD Settings ========
+// ============================
+cvdLength = input.int(14, "CVD Length", group="CVD Settings")
+cvdThreshold = input.float(0, "CVD Threshold (abs value)", step=10, group="CVD Settings")
+
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = high - low
+bodyLength = spread - (upperWick + lowerWick)
+
+percentUpperWick = spread == 0.0 ? 0.0 : upperWick / spread
+percentLowerWick = spread == 0.0 ? 0.0 : lowerWick / spread
+percentBodyLength = spread == 0.0 ? 0.0 : bodyLength / spread
+
+buyingVolume = close > open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
+sellingVolume = close < open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
+
+cumulativeBuyingVolume = ta.ema(buyingVolume, cvdLength)
+cumulativeSellingVolume = ta.ema(sellingVolume, cvdLength)
+cvdDelta = cumulativeBuyingVolume - cumulativeSellingVolume
+
+cvdBullish = cvdDelta > cvdThreshold
+cvdBearish = cvdDelta < -cvdThreshold
+
+plot(cvdDelta, title="CVD Delta", display=display.data_window)
+
+// ============================
+// ==== Volatility Stop (SL) ===
+// ============================
+useVolStop = input.bool(true, "Use Volatility Stop", group="Volatility Stop")
+vsLength = input.int(20, "Length", minval=2, group="Volatility Stop")
+vsFactor = input.float(2.0, "Multiplier", minval=0.25, step=0.25, group="Volatility Stop")
+vsSource = input.source(close, "Source", group="Volatility Stop")
+vsShowLine = input.bool(false, "Show Stop Line", group="Volatility Stop")
+vsShowDots = input.bool(true, "Show Stop Dots", group="Volatility Stop")
+vsLineWidth = input.int(1, "Stop Line Width", minval=1, maxval=5, group="Volatility Stop")
+
+// ============================
+// ===== Display Settings =====
+// ============================
+useBarColor = input.bool(true, "Color Bars When Aligned", group="Display")
+barTransp = input.int(50, "Bar Color Transparency", minval=0, maxval=100, group="Display")
+bgTransp = input.int(86, "Background Transparency", minval=0, maxval=100, group="Display")
+
+bullColor = #009988
+bearColor = #8e8989
+
+// ======================
+// ==== Alignment I/O ===
+// ======================
+alignLong = jmaLong and kernelBullish
+alignShort = jmaShort and kernelBearish
+
+// Start-of-alignment only with cycle gating (non-repainting at bar close)
+var int cycleDir = 0 // 1 = long cycle active, -1 = short cycle active, 0 = none
+alignLongStart = barstate.isconfirmed and alignLong and not alignLong[1] and (cycleDir != 1)
+alignShortStart = barstate.isconfirmed and alignShort and not alignShort[1] and (cycleDir != -1)
+cycleDir := alignLongStart ? 1 : alignShortStart ? -1 : cycleDir
+cycleDir := cycleDir == 1 and alignShort ? 0 : cycleDir == -1 and alignLong ? 0 : cycleDir
+
+plotshape(alignLongStart, title="Align Long Start", style=shape.labelup, location=location.belowbar, color=bullColor, size=size.tiny, text="")
+plotshape(alignShortStart, title="Align Short Start", style=shape.labeldown, location=location.abovebar, color=bearColor, size=size.tiny, text="")
+
+barColorSeries = alignLong ? color.new(bullColor, barTransp) : alignShort ? color.new(bearColor, barTransp) : na
+barcolor(useBarColor ? barColorSeries : na)
+
+// Confirmed-bar trigger background: only paints on closed candles.
+bgLong = barstate.isconfirmed and useBarColor and alignLong and cvdBullish and priceAboveAllTriggers
+bgShort = barstate.isconfirmed and useBarColor and alignShort and cvdBearish and priceBelowAllTriggers
+bgColorSeries = bgLong ? color.new(bullColor, bgTransp) : bgShort ? color.new(bearColor, bgTransp) : na
+bgcolor(bgColorSeries, title="Trigger Background")
+
+// Alerts
+alertcondition(alignLongStart, title="Kernel+JMA Align Long (Start)", message="SZT Align Long ▲ | {{ticker}}@{{close}} | ({{interval}})")
+alertcondition(alignShortStart, title="Kernel+JMA Align Short (Start)", message="SZT Align Short ▼ | {{ticker}}@{{close}} | ({{interval}})")
+alertcondition(bgLong, title="SZT Align + CVD + Triggers Long", message="SZT Trend align + CVD LONG ✅ | {{ticker}}@{{close}} | ({{interval}})")
+alertcondition(bgShort, title="SZT Align + CVD + Triggers Short", message="SZT Trend align + CVD SHORT ✅ | {{ticker}}@{{close}} | ({{interval}})")
+
+volStop(src, atrlen, atrmult) =>
+    if not na(src)
+        var float regimeMax = src
+        var float regimeMin = src
+        var bool uptrend = true
+        var float stop = na
+        atrM = ta.atr(atrlen) * atrmult
+        regimeMax := math.max(regimeMax, src)
+        regimeMin := math.min(regimeMin, src)
+        stop := nz(uptrend ? math.max(stop, regimeMax - atrM) : math.min(stop, regimeMin + atrM), src)
+        uptrend := src - stop >= 0.0
+        prevUp = bar_index > 0 ? uptrend[1] : true
+        if uptrend != prevUp
+            regimeMax := src
+            regimeMin := src
+            stop := uptrend ? regimeMax - atrM : regimeMin + atrM
+        [stop, uptrend]
+
+[vsStop, vsUp] = volStop(vsSource, vsLength, vsFactor)
+vsColor = vsUp ? color.new(#09d647, 0) : color.new(#8f8b8a, 0)
+plot(useVolStop and vsShowLine ? vsStop : na, title="Volatility Stop", color=vsColor, linewidth=vsLineWidth)
+plot(useVolStop and vsShowDots ? vsStop : na, title="Volatility Stop Dots", style=plot.style_cross, color=vsColor, linewidth=1)
+
+plot(useVolStop ? vsStop : na, title="SL Level (VolStop)", display=display.data_window)

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -9,6 +9,8 @@ import jdehorty/KernelFunctions/2 as kernels
 trigger1Tf = input.timeframe("120", "Trigger 1) Higher Timeframe Candle Reference (2h)", group="Trigger Settings")
 trigger2Tf = input.timeframe("60", "Trigger 2) Medium Timeframe Candle Reference (1h)", group="Trigger Settings")
 trigger3Tf = input.timeframe("15", "Trigger 3) Lower Timeframe Candle Reference (15m)", group="Trigger Settings")
+trigger4AtrAvgLen = input.int(15, "Trigger 4) ATR Average Length", minval=1, group="Trigger Settings")
+trigger4AtrMax = input.float(8.0, "Trigger 4) ATR Average Max", minval=0.0, step=0.25, group="Trigger Settings")
 triggerTimezoneMode = input.string("UTC-4 (fixed)", "Trigger Timezone", options=["UTC-4 (fixed)", "America/New_York (DST)", "Exchange"], tooltip="Controls where 2h/1h/15m trigger candles start. Use UTC-4 fixed or New York DST-aware clock.", group="Trigger Settings")
 showTriggerDebug = input.bool(false, "Show Trigger Debug Table", group="Trigger Settings")
 triggerTimezone = triggerTimezoneMode == "Exchange" ? syminfo.timezone : triggerTimezoneMode == "America/New_York (DST)" ? "America/New_York" : "Etc/GMT+4"
@@ -30,9 +32,11 @@ priceAboveAllTriggers = close > trigger1Level and close > trigger2Level and clos
 priceBelowAllTriggers = close < trigger1Level and close < trigger2Level and close < trigger3Level
 trigger1LongBias = close > trigger1Level
 trigger1ShortBias = close < trigger1Level
+trigger4AtrAvg = ta.atr(trigger4AtrAvgLen)
+trigger4VolatilityOk = trigger4AtrAvg <= trigger4AtrMax
 
 if showTriggerDebug and barstate.islast
-    var table dbg = table.new(position.top_right, 2, 8, border_width=1)
+    var table dbg = table.new(position.top_right, 2, 10, border_width=1)
     table.cell(dbg, 0, 0, "TZ", text_color=color.white, bgcolor=color.new(color.black, 0))
     table.cell(dbg, 1, 0, triggerTimezone, text_color=color.white, bgcolor=color.new(color.black, 0))
     table.cell(dbg, 0, 1, "2h start", text_color=color.white, bgcolor=color.new(color.black, 0))
@@ -49,6 +53,10 @@ if showTriggerDebug and barstate.islast
     table.cell(dbg, 1, 6, str.tostring(priceAboveAllTriggers), text_color=color.white, bgcolor=color.new(color.black, 0))
     table.cell(dbg, 0, 7, "Below all", text_color=color.white, bgcolor=color.new(color.black, 0))
     table.cell(dbg, 1, 7, str.tostring(priceBelowAllTriggers), text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 0, 8, "ATR Avg", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 1, 8, str.tostring(trigger4AtrAvg, format.mintick), text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 0, 9, "ATR <= Max", text_color=color.white, bgcolor=color.new(color.black, 0))
+    table.cell(dbg, 1, 9, str.tostring(trigger4VolatilityOk), text_color=color.white, bgcolor=color.new(color.black, 0))
 
 // ============================
 // ==== Kernel Settings =======
@@ -175,8 +183,8 @@ barcolor(useBarColor ? barColorSeries : na)
 
 // Confirmed-bar trigger background: only paints on closed candles.
 // Background follows active alignment and additionally requires Trigger-1 open bias.
-bgLong = barstate.isconfirmed and useBarColor and alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias
-bgShort = barstate.isconfirmed and useBarColor and alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias
+bgLong = barstate.isconfirmed and useBarColor and alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
+bgShort = barstate.isconfirmed and useBarColor and alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
 bgColorSeries = bgLong ? color.new(bullColor, bgTransp) : bgShort ? color.new(bearColor, bgTransp) : na
 bgcolor(bgColorSeries, title="Trigger Background")
 

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -10,15 +10,15 @@ trigger1Tf = input.timeframe("120", "Trigger 1) Higher Timeframe Candle Referenc
 trigger2Tf = input.timeframe("60", "Trigger 2) Medium Timeframe Candle Reference (1h)", group="Trigger Settings")
 trigger3Tf = input.timeframe("15", "Trigger 3) Lower Timeframe Candle Reference (15m)", group="Trigger Settings")
 
-trigger1Price = request.security(syminfo.tickerid, trigger1Tf, close, barmerge.gaps_off, barmerge.lookahead_off)
-trigger2Price = request.security(syminfo.tickerid, trigger2Tf, close, barmerge.gaps_off, barmerge.lookahead_off)
-trigger3Price = request.security(syminfo.tickerid, trigger3Tf, close, barmerge.gaps_off, barmerge.lookahead_off)
-trigger1Open = request.security(syminfo.tickerid, trigger1Tf, open, barmerge.gaps_off, barmerge.lookahead_off)
+// Use open-based HTF references so trigger checks work on the active HTF candle.
+trigger1Level = request.security(syminfo.tickerid, trigger1Tf, open, barmerge.gaps_off, barmerge.lookahead_off)
+trigger2Level = request.security(syminfo.tickerid, trigger2Tf, open, barmerge.gaps_off, barmerge.lookahead_off)
+trigger3Level = request.security(syminfo.tickerid, trigger3Tf, open, barmerge.gaps_off, barmerge.lookahead_off)
 
-priceAboveAllTriggers = close > trigger1Price and close > trigger2Price and close > trigger3Price
-priceBelowAllTriggers = close < trigger1Price and close < trigger2Price and close < trigger3Price
-trigger1LongBias = close > trigger1Open
-trigger1ShortBias = close < trigger1Open
+priceAboveAllTriggers = close > trigger1Level and close > trigger2Level and close > trigger3Level
+priceBelowAllTriggers = close < trigger1Level and close < trigger2Level and close < trigger3Level
+trigger1LongBias = close > trigger1Level
+trigger1ShortBias = close < trigger1Level
 
 // ============================
 // ==== Kernel Settings =======

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -23,11 +23,11 @@ trigger1ShortBias = close < trigger1Open
 // ============================
 // ==== Kernel Settings =======
 // ============================
-h = input.int(8, "Lookback Window", minval=3, tooltip="Bars used for estimation. Recommended: 3-50", group="Kernel Settings")
-r = input.float(8.0, "Relative Weighting", step=0.25, tooltip="Relative weighting of time frames. Recommended: 0.25-25", group="Kernel Settings")
-x = input.int(25, "Regression Level", tooltip="Starting bar index for regression. Smaller = tighter fit. Recommended: 2-25", group="Kernel Settings")
-lag = input.int(2, "Lag", tooltip="Lag for crossover detection. Recommended: 1-2", group="Kernel Settings")
-source = input.source(close, "Source", group="Kernel Settings")
+h = 4
+r = 4.0
+x = 10
+lag = 1
+source = close
 kernelLineWidth = input.int(1, "Kernel Line Width", minval=1, maxval=5, group="Kernel Settings")
 kernelBullColor = input.color(#009988, "Kernel Bull Color", group="Kernel Settings")
 kernelBearColor = input.color(#747171, "Kernel Bear Color", group="Kernel Settings")
@@ -46,8 +46,8 @@ plot(yhat1, title="Kernel", color=kernelPlotColor, linewidth=kernelLineWidth)
 // ====== JMA Settings ========
 // ============================
 jmaLength = 20
-jmaPhase = input.int(50, "JMA Phase", minval=-100, maxval=100, group="JMA Settings")
-jmaPower = input.int(2, "JMA Power", minval=1, group="JMA Settings")
+jmaPhase = 40
+jmaPower = 2
 jmaLineWidth = input.int(1, "JMA Line Width", minval=1, maxval=5, group="JMA Settings")
 jmaBullColor = input.color(#009988, "JMA Bull Color", group="JMA Settings")
 jmaBearColor = input.color(#959595, "JMA Bear Color", group="JMA Settings")
@@ -78,8 +78,8 @@ jmaShort = isDown and close < jma
 // ============================
 // ====== CVD Settings ========
 // ============================
-cvdLength = input.int(14, "CVD Length", group="CVD Settings")
-cvdThreshold = input.float(0, "CVD Threshold (abs value)", step=10, group="CVD Settings")
+cvdLength = 14
+cvdThreshold = 10.0
 
 upperWick = close > open ? high - close : high - open
 lowerWick = close > open ? open - low : close - low
@@ -106,9 +106,9 @@ plot(cvdDelta, title="CVD Delta", display=display.data_window)
 // ==== Volatility Stop (SL) ===
 // ============================
 useVolStop = input.bool(true, "Use Volatility Stop", group="Volatility Stop")
-vsLength = input.int(20, "Length", minval=2, group="Volatility Stop")
-vsFactor = input.float(2.0, "Multiplier", minval=0.25, step=0.25, group="Volatility Stop")
-vsSource = input.source(close, "Source", group="Volatility Stop")
+vsLength = 20
+vsFactor = 2.0
+vsSource = close
 vsShowLine = input.bool(false, "Show Stop Line", group="Volatility Stop")
 vsShowDots = input.bool(true, "Show Stop Dots", group="Volatility Stop")
 vsLineWidth = input.int(1, "Stop Line Width", minval=1, maxval=5, group="Volatility Stop")

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -32,6 +32,17 @@ priceAboveAllTriggers = close > trigger1Level and close > trigger2Level and clos
 priceBelowAllTriggers = close < trigger1Level and close < trigger2Level and close < trigger3Level
 trigger1LongBias = close > trigger1Level
 trigger1ShortBias = close < trigger1Level
+var int cycleDir = 0 // 1 = long cycle active, -1 = short cycle active, 0 = none
+
+// --- RESETEO DE CICLO POR TIMEFRAMES SUPERIORES ---
+// Este bloque debe ejecutarse ANTES de calcular bgLong/bgShort
+if na(trigger1Level[1]) or trigger1Level != trigger1Level[1] or na(trigger2Level[1]) or trigger2Level != trigger2Level[1]
+    cycleDir := 0
+
+if (cycleDir == -1 and trigger1LongBias)
+    cycleDir := 0
+if (cycleDir == 1 and trigger1ShortBias)
+    cycleDir := 0
 trigger4AtrAvg = ta.atr(trigger4AtrAvgLen)
 trigger4VolatilityOk = trigger4AtrAvg <= trigger4AtrMax
 
@@ -169,7 +180,6 @@ alignLong = jmaLong and kernelBullish
 alignShort = jmaShort and kernelBearish
 
 // Start-of-alignment only with cycle gating (non-repainting at bar close)
-var int cycleDir = 0 // 1 = long cycle active, -1 = short cycle active, 0 = none
 alignLongStart = barstate.isconfirmed and alignLong and not alignLong[1] and (cycleDir != 1)
 alignShortStart = barstate.isconfirmed and alignShort and not alignShort[1] and (cycleDir != -1)
 cycleDir := alignLongStart ? 1 : alignShortStart ? -1 : cycleDir
@@ -185,15 +195,6 @@ barcolor(useBarColor ? barColorSeries : na)
 // Background follows active alignment and additionally requires Trigger-1 open bias.
 bgLong = barstate.isconfirmed and useBarColor and alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk and cycleDir != -1
 bgShort = barstate.isconfirmed and useBarColor and alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk and cycleDir != 1
-// Reset ciclo por cambio en timeframes superiores
-if na(trigger1Level[1]) or trigger1Level != trigger1Level[1] or na(trigger2Level[1]) or trigger2Level != trigger2Level[1]
-    cycleDir := 0
-
-// Reset ciclo si la tendencia superior contradice el ciclo actual
-if (cycleDir == -1 and trigger1LongBias)
-    cycleDir := 0
-if (cycleDir == 1 and trigger1ShortBias)
-    cycleDir := 0
 bgColorSeries = bgLong ? color.new(bullColor, bgTransp) : bgShort ? color.new(bearColor, bgTransp) : na
 bgcolor(bgColorSeries, title="Trigger Background")
 

--- a/SZT_Trend_Align_CVD.pine
+++ b/SZT_Trend_Align_CVD.pine
@@ -183,8 +183,17 @@ barcolor(useBarColor ? barColorSeries : na)
 
 // Confirmed-bar trigger background: only paints on closed candles.
 // Background follows active alignment and additionally requires Trigger-1 open bias.
-bgLong = barstate.isconfirmed and useBarColor and alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
-bgShort = barstate.isconfirmed and useBarColor and alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
+bgLong = barstate.isconfirmed and useBarColor and alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk and cycleDir != -1
+bgShort = barstate.isconfirmed and useBarColor and alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk and cycleDir != 1
+// Reset ciclo por cambio en timeframes superiores
+if na(trigger1Level[1]) or trigger1Level != trigger1Level[1] or na(trigger2Level[1]) or trigger2Level != trigger2Level[1]
+    cycleDir := 0
+
+// Reset ciclo si la tendencia superior contradice el ciclo actual
+if (cycleDir == -1 and trigger1LongBias)
+    cycleDir := 0
+if (cycleDir == 1 and trigger1ShortBias)
+    cycleDir := 0
 bgColorSeries = bgLong ? color.new(bullColor, bgTransp) : bgShort ? color.new(bearColor, bgTransp) : na
 bgcolor(bgColorSeries, title="Trigger Background")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add merged indicator `SZT_Trend_Align_CVD.pine`
- include trigger stack (2h, 1h, 15m, ATR max filter)
- keep Kernel/JMA/CVD/Volatility Stop parameterization for optimization
- stabilize direction logic via forced 2h-bias cycle control
- keep 2h timing anchored to 8:00 session buckets
- **new:** add editable background colors in settings

## Latest change
In `Display` settings, added:
- `bgBullColor = input.color(#009988, "Background Long Color", group="Display")`
- `bgBearColor = input.color(#8e8989, "Background Short Color", group="Display")`

And updated background render:
```pinescript
bgColorSeries = bgLong ? color.new(bgBullColor, bgTransp) : bgShort ? color.new(bgBearColor, bgTransp) : na
```

So background long/short colors are now fully configurable from settings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a9ee259-29fa-419f-b2df-5fb7ff26ec2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a9ee259-29fa-419f-b2df-5fb7ff26ec2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

