### PR TITLE
Implement SZT master session flow for OptiBro backtesting

### DIFF
--- a/SZT_15m_Expanse_OpenImpulse.pine
+++ b/SZT_15m_Expanse_OpenImpulse.pine
@@ -53,7 +53,6 @@ if inWindow and hasValidSessionEnd
 else
     minutesToSessionEnd := na
 withinCutoff = inWindow and hasValidSessionEnd and minutesToSessionEnd < cutOffMinutes
-allowNewEntry = inWindow and not withinCutoff and not tradedThisSubWindow
 trigger1Tf = "120"
 trigger2Tf = "60"
 trigger3Tf = "15"
@@ -115,21 +114,13 @@ bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias
 bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
 bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
 isFirst1mOf15 = isNew15mBar
-var int pendingDir = 0
-if isFirst1mOf15 and inWindow
+if isFirst1mOf15 and inWindow and not withinCutoff and not tradedThisSubWindow and strategy.position_size == 0
     if bgDir[1] == 1
-        pendingDir := 1
-    else if bgDir[1] == -1
-        pendingDir := -1
-    else
-        pendingDir := 0
-if isFirst1mOf15 and pendingDir != 0 and allowNewEntry and strategy.position_size == 0
-    if pendingDir == 1
         strategy.entry("Long", strategy.long)
-    if pendingDir == -1
+        tradedThisSubWindow := true
+    else if bgDir[1] == -1
         strategy.entry("Short", strategy.short)
-    tradedThisSubWindow := true
-    pendingDir := 0
+        tradedThisSubWindow := true
 exitOnLossOfBG = exitOnLossMode == 1
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong
     strategy.close("Long", comment="Long BG Lost")

--- a/SZT_15m_Expanse_OpenImpulse.pine
+++ b/SZT_15m_Expanse_OpenImpulse.pine
@@ -53,6 +53,7 @@ if inWindow and hasValidSessionEnd
 else
     minutesToSessionEnd := na
 withinCutoff = inWindow and hasValidSessionEnd and minutesToSessionEnd < cutOffMinutes
+allowNewEntry = inWindow and not withinCutoff and not tradedThisSubWindow
 trigger1Tf = "120"
 trigger2Tf = "60"
 trigger3Tf = "15"
@@ -113,12 +114,11 @@ alignShort = jmaShort and kernelBearish
 bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
 bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
 bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
-isFirst1mOf15 = isNew15mBar
-if isFirst1mOf15 and inWindow and not withinCutoff and not tradedThisSubWindow and strategy.position_size == 0
-    if bgDir[1] == 1
+if allowNewEntry and strategy.position_size == 0
+    if bgLong and not bgShort
         strategy.entry("Long", strategy.long)
         tradedThisSubWindow := true
-    else if bgDir[1] == -1
+    else if bgShort and not bgLong
         strategy.entry("Short", strategy.short)
         tradedThisSubWindow := true
 exitOnLossOfBG = exitOnLossMode == 1

--- a/SZT_15m_Expanse_OpenImpulse.pine
+++ b/SZT_15m_Expanse_OpenImpulse.pine
@@ -1,0 +1,150 @@
+//@version=6
+strategy("SZT 15m Expanse", overlay=true, process_orders_on_close=false, calc_on_every_tick=true, pyramiding=0, default_qty_type=strategy.fixed, default_qty_value=1)
+import jdehorty/KernelFunctions/2 as kernels
+kernel_h = input.int(4, "Kernel Lookback (h)", minval=2, step=1)
+kernel_r = input.float(4.0, "Kernel Relative Weight (r)", step=0.5)
+kernel_x = input.int(10, "Kernel Regression Level (x)", minval=2, step=1)
+kernel_lag = input.int(1, "Kernel Lag", minval=1, maxval=3)
+jmaPhase = input.int(40, "JMA Phase", minval=-100, maxval=100, step=1)
+jmaPower = input.int(2, "JMA Power", minval=1, maxval=5)
+cvdLength = input.int(14, "CVD Length", minval=1, step=1)
+cvdThreshold = input.float(10.0, "CVD Threshold", step=5.0)
+tradeSession = input.session("0800-0900", "Global Trading Window")
+sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"])
+cutOffMinutes = input.int(4, "Cut-Off (Minutes before close)", minval=1, maxval=5)
+stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25)
+tpPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25)
+exitOnLossMode = input.int(1, "Exit on BG Loss (1=Yes, 0=No)", minval=0, maxval=1, step=1)
+sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
+isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
+inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
+inWindow = isOneMinute and inWindowRaw
+subWindowTime = time("15", "", sessionTz)
+isNew15mBar = na(subWindowTime[1]) or subWindowTime != subWindowTime[1]
+windowStart = inWindow and isNew15mBar
+var bool tradedThisSubWindow = false
+if barstate.isnew and windowStart
+    tradedThisSubWindow := false
+if barstate.isnew and not inWindow and inWindow[1]
+    tradedThisSubWindow := false
+var int sessionEndHour = 0
+var int sessionEndMinute = 0
+var float minutesToSessionEnd = na
+var bool hasValidSessionEnd = false
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ""
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ""
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidToken = str.length(endTokenClean) >= 4
+endHourRaw = hasValidToken ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidToken ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+if windowStart
+    hasValidSessionEnd := hasValidToken and not na(endHourRaw) and not na(endMinuteRaw)
+    if hasValidSessionEnd
+        sessionEndHour := int(endHourRaw)
+        sessionEndMinute := int(endMinuteRaw)
+if inWindow and hasValidSessionEnd
+    currentTs = barstate.isrealtime ? timenow : time
+    currentMinuteOfDay = hour(currentTs, sessionTz) * 60 + minute(currentTs, sessionTz)
+    sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+    minutesToSessionEnd := sessionEndMinuteOfDay - currentMinuteOfDay
+else
+    minutesToSessionEnd := na
+withinCutoff = inWindow and hasValidSessionEnd and minutesToSessionEnd < cutOffMinutes
+allowNewEntry = inWindow and not withinCutoff and not tradedThisSubWindow
+trigger1Tf = "120"
+trigger2Tf = "60"
+trigger3Tf = "15"
+triggerTimezone = "Etc/GMT+4"
+trigger4AtrAvgLen = 15
+trigger4AtrMax = 8.0
+jmaLength = 20
+t1 = time(trigger1Tf, "", triggerTimezone)
+t2 = time(trigger2Tf, "", triggerTimezone)
+t3 = time(trigger3Tf, "", triggerTimezone)
+var float trigger1Level = na
+var float trigger2Level = na
+var float trigger3Level = na
+trigger1Level := na(t1[1]) or t1 != t1[1] ? open : nz(trigger1Level[1], open)
+trigger2Level := na(t2[1]) or t2 != t2[1] ? open : nz(trigger2Level[1], open)
+trigger3Level := na(t3[1]) or t3 != t3[1] ? open : nz(trigger3Level[1], open)
+priceAboveAllTriggers = close > trigger1Level and close > trigger2Level and close > trigger3Level
+priceBelowAllTriggers = close < trigger1Level and close < trigger2Level and close < trigger3Level
+trigger1LongBias = close > trigger1Level
+trigger1ShortBias = close < trigger1Level
+trigger4AtrAvg = ta.atr(trigger4AtrAvgLen)
+trigger4VolatilityOk = trigger4AtrAvg <= trigger4AtrMax
+source = close
+yhat1 = kernels.rationalQuadratic(source, kernel_h, kernel_r, kernel_x)
+kernelSmoothLookback = math.max(1, kernel_h - kernel_lag)
+yhat2 = kernels.gaussian(source, kernelSmoothLookback, kernel_x)
+kernelBullish = yhat2 >= yhat1
+kernelBearish = yhat2 <= yhat1
+phaseRatio = jmaPhase < -100 ? 0.5 : jmaPhase > 100 ? 2.5 : jmaPhase / 100 + 1.5
+beta = 0.45 * (jmaLength - 1) / (0.45 * (jmaLength - 1) + 2)
+alpha = math.pow(beta, jmaPower)
+var float jma = na
+var float e0 = na
+var float e1 = na
+var float e2 = na
+e0 := (1 - alpha) * source + alpha * nz(e0[1])
+e1 := (source - e0) * (1 - beta) + beta * nz(e1[1])
+e2 := (e0 + phaseRatio * e1 - nz(jma[1])) * math.pow(1 - alpha, 2) + math.pow(alpha, 2) * nz(e2[1])
+jma := e2 + nz(jma[1])
+jmaLong = jma > jma[1] and close > jma
+jmaShort = jma < jma[1] and close < jma
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpperWick = upperWick / spread
+percentLowerWick = lowerWick / spread
+percentBodyLength = bodyLength / spread
+buyingVolume = close > open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
+sellingVolume = close < open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
+cumulativeBuyingVolume = ta.ema(buyingVolume, cvdLength)
+cumulativeSellingVolume = ta.ema(sellingVolume, cvdLength)
+cvdDelta = cumulativeBuyingVolume - cumulativeSellingVolume
+cvdBullish = cvdDelta > cvdThreshold
+cvdBearish = cvdDelta < -cvdThreshold
+alignLong = jmaLong and kernelBullish
+alignShort = jmaShort and kernelBearish
+bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
+bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
+bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
+isFirst1mOf15 = isNew15mBar
+var int pendingDir = 0
+if isFirst1mOf15 and inWindow
+    if bgDir[1] == 1
+        pendingDir := 1
+    else if bgDir[1] == -1
+        pendingDir := -1
+    else
+        pendingDir := 0
+if isFirst1mOf15 and pendingDir != 0 and allowNewEntry and strategy.position_size == 0
+    if pendingDir == 1
+        strategy.entry("Long", strategy.long)
+    if pendingDir == -1
+        strategy.entry("Short", strategy.short)
+    tradedThisSubWindow := true
+    pendingDir := 0
+exitOnLossOfBG = exitOnLossMode == 1
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong
+    strategy.close("Long", comment="Long BG Lost")
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort
+    strategy.close("Short", comment="Short BG Lost")
+barsSinceWindowStart = ta.barssince(windowStart)
+isLastWindowBar = inWindow and barsSinceWindowStart == 14
+if isLastWindowBar and strategy.position_size != 0
+    strategy.close_all(comment="Window Close (last bar)", immediately=true)
+if strategy.position_size > 0
+    strategy.exit("Long Exit", "Long", stop=strategy.position_avg_price - stopPts, limit=strategy.position_avg_price + tpPts)
+if strategy.position_size < 0
+    strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + stopPts, limit=strategy.position_avg_price - tpPts)
+bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
+plotchar(tradedThisSubWindow, "tradedThisSubWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
+plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
+plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
+plot(minutesToSessionEnd, "minutesToSessionEnd", color=color.new(color.white, 0), display=display.data_window)

--- a/SZT_15m_Expanse_OpenImpulse.pine
+++ b/SZT_15m_Expanse_OpenImpulse.pine
@@ -12,6 +12,7 @@ cvdThreshold = input.float(10.0, "CVD Threshold", step=5.0)
 tradeSession = input.session("0800-0900", "Global Trading Window")
 sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"])
 cutOffMinutes = input.int(4, "Cut-Off (Minutes before close)", minval=1, maxval=5)
+minScore = input.int(3, "Min Score", minval=1, maxval=5)
 stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25)
 tpPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25)
 exitOnLossMode = input.int(1, "Exit on BG Loss (1=Yes, 0=No)", minval=0, maxval=1, step=1)
@@ -53,7 +54,6 @@ if inWindow and hasValidSessionEnd
 else
     minutesToSessionEnd := na
 withinCutoff = inWindow and hasValidSessionEnd and minutesToSessionEnd < cutOffMinutes
-allowNewEntry = inWindow and not withinCutoff and not tradedThisSubWindow
 trigger1Tf = "120"
 trigger2Tf = "60"
 trigger3Tf = "15"
@@ -111,10 +111,22 @@ cvdBullish = cvdDelta > cvdThreshold
 cvdBearish = cvdDelta < -cvdThreshold
 alignLong = jmaLong and kernelBullish
 alignShort = jmaShort and kernelBearish
-bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
-bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
+longScore = 0
+longScore += alignLong ? 1 : 0
+longScore += cvdBullish ? 1 : 0
+longScore += priceAboveAllTriggers ? 1 : 0
+longScore += trigger1LongBias ? 1 : 0
+longScore += trigger4VolatilityOk ? 1 : 0
+shortScore = 0
+shortScore += alignShort ? 1 : 0
+shortScore += cvdBearish ? 1 : 0
+shortScore += priceBelowAllTriggers ? 1 : 0
+shortScore += trigger1ShortBias ? 1 : 0
+shortScore += trigger4VolatilityOk ? 1 : 0
+bgLong = longScore >= minScore and longScore > shortScore
+bgShort = shortScore >= minScore and shortScore > longScore
 bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
-if allowNewEntry and strategy.position_size == 0
+if inWindow and not withinCutoff and not tradedThisSubWindow and strategy.position_size == 0
     if bgLong and not bgShort
         strategy.entry("Long", strategy.long)
         tradedThisSubWindow := true

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -24,7 +24,8 @@ sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
 isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
 inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
 inWindow = isOneMinute and inWindowRaw
-windowStart = inWindow and not inWindow[1]
+firstBarOfWindow = inWindowRaw and na(time(timeframe.period, tradeSession, sessionTz)[1])
+windowStart = firstBarOfWindow
 var bool tradedThisWindow = false
 if barstate.isnew and not inWindow and inWindow[1]
     tradedThisWindow := false
@@ -146,11 +147,11 @@ if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
 
 exitOnLossOfBG = exitOnLossMode == 1
 if windowStart and not tradedThisWindow and not withinCutoff and strategy.position_size == 0
-    if bgLong and not bgShort
-        strategy.entry("Long", strategy.long, comment="AutoStart Long")
-        tradedThisWindow := true
-    else if bgShort and not bgLong
-        strategy.entry("Short", strategy.short, comment="AutoStart Short")
+    if bgLong or bgShort
+        if bgLong
+            strategy.entry("Long", strategy.long, comment="AutoStart Long")
+        if bgShort
+            strategy.entry("Short", strategy.short, comment="AutoStart Short")
         tradedThisWindow := true
 
 allowSignalEntry = allowNewEntry and not tradedThisWindow and strategy.position_size == 0

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -20,7 +20,8 @@ sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
 isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
 inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
 inWindow = isOneMinute and inWindowRaw
-isNew15mBar = timeframe.isminutes and timeframe.multiplier == 15 and barstate.isnew
+_15mTime = time("15", "", sessionTz)
+isNew15mBar = not na(_15mTime) and na(_15mTime[1])
 windowStart = inWindow and isNew15mBar
 var bool tradedThisWindow = false
 if windowStart

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -20,13 +20,13 @@ sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
 isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
 inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
 inWindow = isOneMinute and inWindowRaw
-isNew15mBar = request.security(syminfo.tickerid, "15", barstate.isnew, lookahead=barmerge.lookahead_off)
+isNew15mBar = timeframe.isminutes and timeframe.multiplier == 15 and barstate.isnew
 windowStart = inWindow and isNew15mBar
-var bool tradedThisSubWindow = false
-if barstate.isnew and windowStart
-    tradedThisSubWindow := false
+var bool tradedThisWindow = false
+if windowStart
+    tradedThisWindow := false
 if barstate.isnew and not inWindow and inWindow[1]
-    tradedThisSubWindow := false
+    tradedThisWindow := false
 var int sessionEndHour = 0
 var int sessionEndMinute = 0
 var float minutesToSessionEnd = na
@@ -53,7 +53,7 @@ if inWindow and hasValidSessionEnd
 else
     minutesToSessionEnd := na
 withinCutoff = inWindow and hasValidSessionEnd and minutesToSessionEnd < cutOffMinutes
-allowNewEntry = inWindow and not withinCutoff and not tradedThisSubWindow
+allowNewEntry = inWindow and not withinCutoff and not tradedThisWindow
 trigger1Tf = "120"
 trigger2Tf = "60"
 trigger3Tf = "15"
@@ -130,25 +130,26 @@ if firstCandleFlipped
 if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
     strategy.close_all(comment="Funky first flip exit", immediately=true)
 exitOnLossOfBG = exitOnLossMode == 1
-if windowStart and not tradedThisSubWindow and not withinCutoff
+if windowStart and not tradedThisWindow and not withinCutoff and strategy.position_size == 0
     if bgLong and not bgShort
         strategy.entry("Long", strategy.long, comment="AutoStart Long")
-        tradedThisSubWindow := true
+        tradedThisWindow := true
     else if bgShort and not bgLong
         strategy.entry("Short", strategy.short, comment="AutoStart Short")
-        tradedThisSubWindow := true
-allowSignalEntry = allowNewEntry and not tradedThisSubWindow
+        tradedThisWindow := true
+allowSignalEntry = allowNewEntry and not tradedThisWindow and strategy.position_size == 0
 if allowSignalEntry and longFlipSignal
     strategy.entry("Long", strategy.long, comment="Flip Long")
-    tradedThisSubWindow := true
+    tradedThisWindow := true
 if allowSignalEntry and shortFlipSignal
     strategy.entry("Short", strategy.short, comment="Flip Short")
-    tradedThisSubWindow := true
+    tradedThisWindow := true
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong
     strategy.close("Long", comment="Long BG Lost")
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort
     strategy.close("Short", comment="Short BG Lost")
-isLastWindowBar = inWindow and hasValidSessionEnd and minutesToSessionEnd <= 1 and minutesToSessionEnd >= 0
+barsSinceWindowStart = ta.barssince(windowStart)
+isLastWindowBar = inWindow and barsSinceWindowStart == 14
 if isLastWindowBar and strategy.position_size != 0
     strategy.close_all(comment="Window Close (last bar)", immediately=true)
 if strategy.position_size > 0
@@ -156,7 +157,7 @@ if strategy.position_size > 0
 if strategy.position_size < 0
     strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + stopPts, limit=strategy.position_avg_price - tpPts)
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
-plotchar(tradedThisSubWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
+plotchar(tradedThisWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
 plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
 plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
 plot(minutesToSessionEnd, "minutesToSessionEnd", color=color.new(color.white, 0), display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -12,8 +12,10 @@ strategy(
 // ====================================
 // ==== SEÑAL EXTERNA (Background) ====
 // ====================================
-bgLong = input.bool(false, "BG Long (Verde)", group="Signal")
-bgShort = input.bool(false, "BG Short (Rojo)", group="Signal")
+bgLongSource = input.source(close * 0.0, "BG Long Source", group="Signal")
+bgShortSource = input.source(close * 0.0, "BG Short Source", group="Signal")
+bgLong = nz(bgLongSource, 0.0) > 0.0
+bgShort = nz(bgShortSource, 0.0) > 0.0
 
 // ====================================
 // ==== VENTANA + CUT OFF =============
@@ -42,7 +44,6 @@ isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
 inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
 inWindow = isOneMinute and inWindowRaw
 windowStart = inWindow and not inWindow[1]
-barConfirmed = barstate.isconfirmed
 
 // Parse defensivo del fin de sesión para cálculo de cut-off.
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
@@ -68,10 +69,10 @@ allowNewEntry = inWindow and not withinCutoff
 bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
 bgDirPrev = nz(bgDir[1], 0)
 
-flipToLong = barConfirmed and inWindow and bgDir == 1 and bgDirPrev != 1
-flipToShort = barConfirmed and inWindow and bgDir == -1 and bgDirPrev != -1
-autoStartLong = barConfirmed and windowStart and bgDir == 1
-autoStartShort = barConfirmed and windowStart and bgDir == -1
+flipToLong = inWindow and bgDir == 1 and bgDirPrev != 1
+flipToShort = inWindow and bgDir == -1 and bgDirPrev != -1
+autoStartLong = windowStart and bgDir == 1
+autoStartShort = windowStart and bgDir == -1
 
 longEntrySignal = autoStartLong or (flipToLong and not windowStart)
 shortEntrySignal = autoStartShort or (flipToShort and not windowStart)
@@ -86,7 +87,7 @@ if windowStart
     firstCandleDir := bgDir
     firstFlipSeen := false
 
-firstCandleFlipped = barConfirmed and inWindow and not windowStart and not firstFlipSeen and firstCandleDir != 0 and bgDir != firstCandleDir
+firstCandleFlipped = barstate.isconfirmed and inWindow and not windowStart and not firstFlipSeen and firstCandleDir != 0 and bgDir != firstCandleDir
 if firstCandleFlipped
     firstFlipSeen := true
 
@@ -110,10 +111,10 @@ if allowSignalEntry and shortEntrySignal
 tryingReverseToShort = exitOnLossOfBG and allowSignalEntry and shortEntrySignal
 tryingReverseToLong = exitOnLossOfBG and allowSignalEntry and longEntrySignal
 
-if exitOnLossOfBG and barConfirmed and strategy.position_size > 0 and not bgLong and not tryingReverseToShort
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong and not tryingReverseToShort
     strategy.close("Long", comment="Long BG Lost")
 
-if exitOnLossOfBG and barConfirmed and strategy.position_size < 0 and not bgShort and not tryingReverseToLong
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort and not tryingReverseToLong
     strategy.close("Short", comment="Short BG Lost")
 
 if not inWindow and strategy.position_size != 0

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -1,157 +1,131 @@
 //@version=6
 strategy(
-    "SZT Background Edge Strategy (MGC 1m)",
-    shorttitle="SZT BG Edge",
+    "SZT Master Strategy",
     overlay=true,
     pyramiding=0,
     default_qty_type=strategy.fixed,
     default_qty_value=1,
-    calc_on_every_tick=false,
-    process_orders_on_close=false
+    process_orders_on_close=false,
+    calc_on_every_tick=true
 )
 
-import jdehorty/KernelFunctions/2 as kernels
+// ====================================
+// ==== SEÑAL EXTERNA (Background) ====
+// ====================================
+bgLong = input.bool(false, "BG Long (Verde)", group="Signal")
+bgShort = input.bool(false, "BG Short (Rojo)", group="Signal")
 
-// ==============================
-// ===== Backtest controls ======
-// ==============================
-enforceOneMinute = input.bool(true, "Only Trade on 1m", group="Backtest")
-allowLongs = input.bool(true, "Enable Long Trades", group="Backtest")
-allowShorts = input.bool(true, "Enable Short Trades", group="Backtest")
-
-tradeSession = input.session("0815-0830", "Trading Window (HHMM-HHMM)", group="Session")
+// ====================================
+// ==== VENTANA + CUT OFF =============
+// ====================================
+tradeSession = input.session("0815-0830", "Trading Window", group="Session")
 sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"], group="Session")
 sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
-forceCloseOutsideWindow = input.bool(true, "Force Close Outside Window", group="Session")
+cutOffMinutes = input.int(2, "Cut-Off (Minutes before close)", minval=1, maxval=5, group="Session")
 
+// ====================================
+// ==== CONFIG ESTRATEGIA =============
+// ====================================
+exitOnFirstFlip = input.bool(false, "Exit on First Candle Flip (Funky Mode)", group="Strategy")
+
+// ====================================
+// ==== RISK MANAGEMENT (Puntos) ======
+// ====================================
 stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25, group="Risk")
-takeProfitPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25, group="Risk")
+tpPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25, group="Risk")
 
-// ==============================
-// ===== Signal components ======
-// ==============================
-trigger1Tf = input.timeframe("120", "Trigger 1 TF (2h)", group="Signal - Triggers")
-trigger2Tf = input.timeframe("60", "Trigger 2 TF (1h)", group="Signal - Triggers")
-trigger3Tf = input.timeframe("15", "Trigger 3 TF (15m)", group="Signal - Triggers")
-trigger4AtrAvgLen = input.int(15, "Trigger 4 ATR Avg Length", minval=1, group="Signal - Triggers")
-trigger4AtrMax = input.float(8.0, "Trigger 4 ATR Avg Max", minval=0.0, step=0.25, group="Signal - Triggers")
-triggerTimezoneMode = input.string("UTC-4 (fixed)", "Trigger Timezone", options=["UTC-4 (fixed)", "America/New_York (DST)", "Exchange"], group="Signal - Triggers")
-triggerTimezone = triggerTimezoneMode == "Exchange" ? syminfo.timezone : triggerTimezoneMode == "America/New_York (DST)" ? "America/New_York" : "Etc/GMT+4"
-
-kernel_h = input.int(4, "Kernel Lookback (h)", minval=2, group="Signal - Kernel")
-kernel_r = input.float(4.0, "Kernel Relative Weight (r)", step=0.5, group="Signal - Kernel")
-kernel_x = input.int(10, "Kernel Regression Level (x)", minval=2, group="Signal - Kernel")
-kernel_lag = input.int(1, "Kernel Lag", minval=1, maxval=3, group="Signal - Kernel")
-
-jmaLength = input.int(20, "JMA Length", minval=1, group="Signal - JMA")
-jmaPhase = input.int(40, "JMA Phase", minval=-100, maxval=100, group="Signal - JMA")
-jmaPower = input.int(2, "JMA Power", minval=1, maxval=5, group="Signal - JMA")
-
-cvdLength = input.int(14, "CVD Length", minval=1, group="Signal - CVD")
-cvdThreshold = input.float(10.0, "CVD Threshold", step=5.0, group="Signal - CVD")
-
-// ==============================
-// ===== Signal calculations =====
-// ==============================
-source = close
-
-t1 = time(trigger1Tf, "", triggerTimezone)
-t2 = time(trigger2Tf, "", triggerTimezone)
-t3 = time(trigger3Tf, "", triggerTimezone)
-var float trigger1Level = na
-var float trigger2Level = na
-var float trigger3Level = na
-trigger1Level := na(t1[1]) or t1 != t1[1] ? open : nz(trigger1Level[1], open)
-trigger2Level := na(t2[1]) or t2 != t2[1] ? open : nz(trigger2Level[1], open)
-trigger3Level := na(t3[1]) or t3 != t3[1] ? open : nz(trigger3Level[1], open)
-
-priceAboveAllTriggers = close > trigger1Level and close > trigger2Level and close > trigger3Level
-priceBelowAllTriggers = close < trigger1Level and close < trigger2Level and close < trigger3Level
-trigger1LongBias = close > trigger1Level
-trigger1ShortBias = close < trigger1Level
-trigger4AtrAvg = ta.atr(trigger4AtrAvgLen)
-trigger4VolatilityOk = trigger4AtrAvg <= trigger4AtrMax
-
-yhat1 = kernels.rationalQuadratic(source, kernel_h, kernel_r, kernel_x)
-kernelSmoothLookback = math.max(1, kernel_h - kernel_lag)
-yhat2 = kernels.gaussian(source, kernelSmoothLookback, kernel_x)
-kernelBullish = yhat2 >= yhat1
-kernelBearish = yhat2 <= yhat1
-
-phaseRatio = jmaPhase < -100 ? 0.5 : jmaPhase > 100 ? 2.5 : jmaPhase / 100 + 1.5
-beta = 0.45 * (jmaLength - 1) / (0.45 * (jmaLength - 1) + 2)
-alpha = math.pow(beta, jmaPower)
-var float jma = na
-var float e0 = na
-var float e1 = na
-var float e2 = na
-e0 := (1 - alpha) * source + alpha * nz(e0[1])
-e1 := (source - e0) * (1 - beta) + beta * nz(e1[1])
-e2 := (e0 + phaseRatio * e1 - nz(jma[1])) * math.pow(1 - alpha, 2) + math.pow(alpha, 2) * nz(e2[1])
-jma := e2 + nz(jma[1])
-
-jmaLong = jma > jma[1] and close > jma
-jmaShort = jma < jma[1] and close < jma
-
-upperWick = close > open ? high - close : high - open
-lowerWick = close > open ? open - low : close - low
-spread = high - low
-bodyLength = spread - (upperWick + lowerWick)
-percentUpperWick = spread == 0.0 ? 0.0 : upperWick / spread
-percentLowerWick = spread == 0.0 ? 0.0 : lowerWick / spread
-percentBodyLength = spread == 0.0 ? 0.0 : bodyLength / spread
-buyingVolume = close > open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
-sellingVolume = close < open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
-cumulativeBuyingVolume = ta.ema(buyingVolume, cvdLength)
-cumulativeSellingVolume = ta.ema(sellingVolume, cvdLength)
-cvdDelta = cumulativeBuyingVolume - cumulativeSellingVolume
-cvdBullish = cvdDelta > cvdThreshold
-cvdBearish = cvdDelta < -cvdThreshold
-
-alignLong = jmaLong and kernelBullish
-alignShort = jmaShort and kernelBearish
-
-bgLong = barstate.isconfirmed and alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
-bgShort = barstate.isconfirmed and alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
-
-longSignalClose = bgLong and not bgLong[1]
-shortSignalClose = bgShort and not bgShort[1]
-
-// ==============================
-// ===== Execution logic =========
-// ==============================
+// ====================================
+// ==== SESIÓN / TIEMPO ===============
+// ====================================
 isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
-canTradeTf = not enforceOneMinute or isOneMinute
-inWindow = not na(time(timeframe.period, tradeSession, sessionTz))
+inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
+inWindow = isOneMinute and inWindowRaw
 windowStart = inWindow and not inWindow[1]
+barConfirmed = barstate.isconfirmed
 
-var bool tradedThisWindow = false
+// Parse defensivo del fin de sesión para cálculo de cut-off.
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ""
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ""
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidEnd = str.length(endTokenClean) >= 4
+endHourRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+sessionEndHour = hasValidEnd and not na(endHourRaw) ? int(endHourRaw) : 0
+sessionEndMinute = hasValidEnd and not na(endMinuteRaw) ? int(endMinuteRaw) : 0
+sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+barCloseMinuteOfDay = hour(time_close, sessionTz) * 60 + minute(time_close, sessionTz)
+minutesToSessionEnd = sessionEndMinuteOfDay - barCloseMinuteOfDay
+withinCutoff = hasValidEnd and inWindow and minutesToSessionEnd < cutOffMinutes
+allowNewEntry = inWindow and not withinCutoff
+
+// ====================================
+// ==== DIRECCIÓN DEL BG ==============
+// ====================================
+bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
+bgDirPrev = nz(bgDir[1], 0)
+
+flipToLong = barConfirmed and inWindow and bgDir == 1 and bgDirPrev != 1
+flipToShort = barConfirmed and inWindow and bgDir == -1 and bgDirPrev != -1
+autoStartLong = barConfirmed and windowStart and bgDir == 1
+autoStartShort = barConfirmed and windowStart and bgDir == -1
+
+longEntrySignal = autoStartLong or (flipToLong and not windowStart)
+shortEntrySignal = autoStartShort or (flipToShort and not windowStart)
+
+// ====================================
+// ==== FIRST-CANDLE FLIP (FUNKY) =====
+// ====================================
+var int firstCandleDir = 0
+var bool firstFlipSeen = false
+
 if windowStart
-    tradedThisWindow := false
+    firstCandleDir := bgDir
+    firstFlipSeen := false
 
-flat = strategy.position_size == 0
-canSubmit = canTradeTf and inWindow and not tradedThisWindow and flat
+firstCandleFlipped = barConfirmed and inWindow and not windowStart and not firstFlipSeen and firstCandleDir != 0 and bgDir != firstCandleDir
+if firstCandleFlipped
+    firstFlipSeen := true
 
-if canSubmit and allowLongs and longSignalClose and not shortSignalClose
-    strategy.entry("Long", strategy.long)
-    tradedThisWindow := true
+if exitOnFirstFlip and firstCandleFlipped and strategy.position_size != 0
+    strategy.close_all(comment="Funky first flip exit", immediately=true)
 
-if canSubmit and allowShorts and shortSignalClose and not longSignalClose
-    strategy.entry("Short", strategy.short)
-    tradedThisWindow := true
+// ====================================
+// ==== ENTRADAS ======================
+// ====================================
+if allowNewEntry and longEntrySignal
+    strategy.entry("Long", strategy.long, comment=autoStartLong ? "AutoStart Long" : "Flip Long")
 
+if allowNewEntry and shortEntrySignal
+    strategy.entry("Short", strategy.short, comment=autoStartShort ? "AutoStart Short" : "Flip Short")
+
+// ====================================
+// ==== SALIDAS ESTÁNDAR ==============
+// ====================================
+tryingReverseToShort = allowNewEntry and shortEntrySignal
+tryingReverseToLong = allowNewEntry and longEntrySignal
+
+if barConfirmed and strategy.position_size > 0 and not bgLong and not tryingReverseToShort
+    strategy.close("Long", comment="Long BG Lost")
+
+if barConfirmed and strategy.position_size < 0 and not bgShort and not tryingReverseToLong
+    strategy.close("Short", comment="Short BG Lost")
+
+if not inWindow and strategy.position_size != 0
+    strategy.close_all(comment="Window Close", immediately=true)
+
+// ====================================
+// ==== SL / TP FIJOS EN PUNTOS =======
+// ====================================
 if strategy.position_size > 0
-    strategy.exit("Long Exit", "Long", stop=strategy.position_avg_price - stopPts, limit=strategy.position_avg_price + takeProfitPts)
+    strategy.exit("Long Exit", "Long", stop=strategy.position_avg_price - stopPts, limit=strategy.position_avg_price + tpPts)
 if strategy.position_size < 0
-    strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + stopPts, limit=strategy.position_avg_price - takeProfitPts)
+    strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + stopPts, limit=strategy.position_avg_price - tpPts)
 
-if forceCloseOutsideWindow and not inWindow and strategy.position_size != 0
-    strategy.close_all(comment="Window Close")
-
-// ==============================
-// ========= Visuals ============
-// ==============================
-bgcolor(bgLong ? color.new(color.teal, 86) : bgShort ? color.new(color.red, 86) : na, title="Signal Background")
-plotshape(longSignalClose, title="Long signal (close)", style=shape.circle, location=location.belowbar, size=size.tiny, color=color.new(color.teal, 0))
-plotshape(shortSignalClose, title="Short signal (close)", style=shape.circle, location=location.abovebar, size=size.tiny, color=color.new(color.red, 0))
-plot(jma, title="JMA", color=color.new(color.yellow, 0), linewidth=1)
+// ====================================
+// ==== VISUAL ========================
+// ====================================
+bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
+plotchar(withinCutoff ? 1 : 0, "CutOff Active", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -57,7 +57,6 @@ if inWindow and hasValidSessionEnd
 else
     minutesToSessionEnd := na
 withinCutoff = inWindow and hasValidSessionEnd and minutesToSessionEnd < cutOffMinutes
-allowNewEntry = inWindow and not withinCutoff and not tradedThisWindow
 
 trigger1Tf = "120"
 trigger2Tf = "60"
@@ -124,12 +123,6 @@ alignLong = jmaLong and kernelBullish
 alignShort = jmaShort and kernelBearish
 bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
 bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
-bgLong15m = request.security(syminfo.tickerid, "15", bgLong, lookahead=barmerge.lookahead_off)
-bgShort15m = request.security(syminfo.tickerid, "15", bgShort, lookahead=barmerge.lookahead_off)
-barsSinceWindowStart = ta.barssince(windowStart)
-useBg15m = windowStart or (inWindow and barsSinceWindowStart <= 2)
-effectiveBgLong = useBg15m ? bgLong15m : bgLong
-effectiveBgShort = useBg15m ? bgShort15m : bgShort
 
 if not inWindow and strategy.position_size != 0
     strategy.close_all(comment="Window Close", immediately=true)
@@ -146,12 +139,6 @@ if barstate.isconfirmed
             bgDirConfirmed := bgDir
             bgDirCounter := 0
 
-bgDirPrev = nz(bgDir[1], 0)
-flipToLong = inWindow and bgDir == 1 and bgDirPrev != 1
-flipToShort = inWindow and bgDir == -1 and bgDirPrev != -1
-longFlipSignal = flipToLong and not windowStart and not useBg15m
-shortFlipSignal = flipToShort and not windowStart and not useBg15m
-
 var int firstCandleDir = 0
 var bool firstFlipSeen = false
 if windowStart
@@ -167,20 +154,12 @@ if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
 
 exitOnLossOfBG = exitOnLossMode == 1
 if windowStart and not tradedThisWindow and not withinCutoff
-    if effectiveBgLong
-        strategy.entry("Long", strategy.long, comment="AutoStart Long (from 15m)")
+    if bgDirConfirmed == 1
+        strategy.entry("Long", strategy.long, comment="AutoStart Long")
         tradedThisWindow := true
-    if effectiveBgShort
-        strategy.entry("Short", strategy.short, comment="AutoStart Short (from 15m)")
+    if bgDirConfirmed == -1
+        strategy.entry("Short", strategy.short, comment="AutoStart Short")
         tradedThisWindow := true
-
-allowSignalEntry = allowNewEntry and not tradedThisWindow and strategy.position_size == 0
-if allowSignalEntry and longFlipSignal
-    strategy.entry("Long", strategy.long, comment="Flip Long")
-    tradedThisWindow := true
-if allowSignalEntry and shortFlipSignal
-    strategy.entry("Short", strategy.short, comment="Flip Short")
-    tradedThisWindow := true
 
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and bgDirConfirmed != 1
     strategy.close("Long", comment="Long BG Lost")

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -20,8 +20,7 @@ sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
 isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
 inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
 inWindow = isOneMinute and inWindowRaw
-subWindowTime = time("15", "", sessionTz)
-isNew15mBar = na(subWindowTime[1]) or subWindowTime != subWindowTime[1]
+isNew15mBar = request.security(syminfo.tickerid, "15", barstate.isnew, lookahead=barmerge.lookahead_off)
 windowStart = inWindow and isNew15mBar
 var bool tradedThisSubWindow = false
 if barstate.isnew and windowStart
@@ -131,14 +130,14 @@ if firstCandleFlipped
 if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
     strategy.close_all(comment="Funky first flip exit", immediately=true)
 exitOnLossOfBG = exitOnLossMode == 1
-if windowStart and not tradedThisSubWindow and not withinCutoff and strategy.position_size == 0
+if windowStart and not tradedThisSubWindow and not withinCutoff
     if bgLong and not bgShort
         strategy.entry("Long", strategy.long, comment="AutoStart Long")
         tradedThisSubWindow := true
     else if bgShort and not bgLong
         strategy.entry("Short", strategy.short, comment="AutoStart Short")
         tradedThisSubWindow := true
-allowSignalEntry = allowNewEntry and not tradedThisSubWindow and strategy.position_size == 0
+allowSignalEntry = allowNewEntry and not tradedThisSubWindow
 if allowSignalEntry and longFlipSignal
     strategy.entry("Long", strategy.long, comment="Flip Long")
     tradedThisSubWindow := true
@@ -149,8 +148,7 @@ if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and no
     strategy.close("Long", comment="Long BG Lost")
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort
     strategy.close("Short", comment="Short BG Lost")
-barsSinceWindowStart = ta.barssince(windowStart)
-isLastWindowBar = inWindow and barsSinceWindowStart == 14
+isLastWindowBar = inWindow and hasValidSessionEnd and minutesToSessionEnd <= 1 and minutesToSessionEnd >= 0
 if isLastWindowBar and strategy.position_size != 0
     strategy.close_all(comment="Window Close (last bar)", immediately=true)
 if strategy.position_size > 0

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -139,13 +139,13 @@ if barstate.isconfirmed
             bgDirCounter := 0
 
 exitOnLossOfBG = exitOnLossMode == 1
-if windowStart and not tradedThisWindow
-    if not withinCutoff
-        if bgDirConfirmed == 1
-            strategy.entry("Long", strategy.long, comment="AutoStart Long")
-        if bgDirConfirmed == -1
-            strategy.entry("Short", strategy.short, comment="AutoStart Short")
-    tradedThisWindow := true
+if windowStart and not tradedThisWindow and not withinCutoff
+    if bgDir == 1
+        strategy.entry("Long", strategy.long, comment="AutoStart Long")
+        tradedThisWindow := true
+    if bgDir == -1
+        strategy.entry("Short", strategy.short, comment="AutoStart Short")
+        tradedThisWindow := true
 
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and bgDirConfirmed != 1
     strategy.close("Long", comment="Long BG Lost")

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -19,6 +19,7 @@ stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25)
 tpPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25)
 exitOnLossMode = input.int(1, "Exit on BG Loss (1=Yes, 0=No)", minval=0, maxval=1, step=1)
 firstFlipMode = input.int(0, "Exit on First Candle Flip (1=Yes, 0=No)", minval=0, maxval=1, step=1)
+confirmationBars = input.int(3, "BG Confirmation Bars", minval=1, maxval=10, step=1)
 
 sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
 isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
@@ -134,6 +135,17 @@ if not inWindow and strategy.position_size != 0
     strategy.close_all(comment="Window Close", immediately=true)
 
 bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
+var int bgDirConfirmed = 0
+var int bgDirCounter = 0
+if barstate.isconfirmed
+    if bgDir == bgDirConfirmed
+        bgDirCounter := 0
+    else
+        bgDirCounter := bgDir == nz(bgDir[1], 0) ? bgDirCounter + 1 : 1
+        if bgDirCounter >= confirmationBars
+            bgDirConfirmed := bgDir
+            bgDirCounter := 0
+
 bgDirPrev = nz(bgDir[1], 0)
 flipToLong = inWindow and bgDir == 1 and bgDirPrev != 1
 flipToShort = inWindow and bgDir == -1 and bgDirPrev != -1
@@ -170,9 +182,9 @@ if allowSignalEntry and shortFlipSignal
     strategy.entry("Short", strategy.short, comment="Flip Short")
     tradedThisWindow := true
 
-if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and bgDirConfirmed != 1
     strategy.close("Long", comment="Long BG Lost")
-if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and bgDirConfirmed != -1
     strategy.close("Short", comment="Short BG Lost")
 
 if strategy.position_size > 0
@@ -185,5 +197,6 @@ plotchar(tradedThisWindow, "tradedThisWindow", "", location.top, color=color.new
 plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
 plotchar(windowStart, "windowStart", "", location.top, color=color.new(color.blue, 0), size=size.tiny, display=display.data_window)
 plotchar(bgLong, "bgLong (1er vela)", "", location.top, color=color.new(color.green, 0), size=size.tiny, display=display.data_window)
+plotchar(bgDirConfirmed, "bgDirConfirmed", "", location.top, color=color.new(color.purple, 0), size=size.tiny, display=display.data_window)
 plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
 plot(minutesToSessionEnd, "minutesToSessionEnd", color=color.new(color.white, 0), display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -165,3 +165,4 @@ if strategy.position_size < 0
 
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
 plotchar(withinCutoff ? 1 : 0, "CutOff Active", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
+plotchar(tradedThisWindow ? 1 : 0, "Traded This Window", "", location.top, color=color.new(color.yellow, 0), size=size.tiny, display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -1,5 +1,5 @@
 //@version=6
-strategy("SZT Unificada OptiBro", overlay=true, process_orders_on_close=false, calc_on_every_tick=true, pyramiding=0, default_qty_type=strategy.fixed, default_qty_value=1)
+strategy("SZT 15m Expanse", overlay=true, process_orders_on_close=false, calc_on_every_tick=true, pyramiding=0, default_qty_type=strategy.fixed, default_qty_value=1)
 
 import jdehorty/KernelFunctions/2 as kernels
 
@@ -14,7 +14,7 @@ cvdThreshold = input.float(10.0, "CVD Threshold", step=5.0)
 
 tradeSession = input.session("0815-0830", "Trading Window")
 sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"])
-cutOffMinutes = input.int(2, "Cut-Off (Minutes before close)", minval=1, maxval=5)
+cutOffMinutes = input.int(4, "Cut-Off (Minutes before close)", minval=1, maxval=5)
 stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25)
 tpPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25)
 exitOnLossMode = input.int(1, "Exit on BG Loss (1=Yes, 0=No)", minval=0, maxval=1, step=1)
@@ -29,22 +29,33 @@ var bool tradedThisWindow = false
 if barstate.isnew and not inWindow and inWindow[1]
     tradedThisWindow := false
 
+var int sessionEndHour = 0
+var int sessionEndMinute = 0
+var float minutesToSessionEnd = na
+var bool hasValidSessionEnd = false
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
 sessionRanges = str.split(sessionCore, ",")
 lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ""
 rangeParts = str.split(lastRange, "-")
 endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ""
 endTokenClean = str.replace_all(endToken, ":", "")
-hasValidEnd = str.length(endTokenClean) >= 4
-endHourRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
-endMinuteRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
-sessionEndHour = hasValidEnd and not na(endHourRaw) ? int(endHourRaw) : 0
-sessionEndMinute = hasValidEnd and not na(endMinuteRaw) ? int(endMinuteRaw) : 0
-sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
-barCloseMinuteOfDay = hour(time_close, sessionTz) * 60 + minute(time_close, sessionTz)
-minutesToSessionEnd = sessionEndMinuteOfDay - barCloseMinuteOfDay
-withinCutoff = hasValidEnd and inWindow and minutesToSessionEnd < cutOffMinutes
-allowNewEntry = inWindow and not withinCutoff
+hasValidToken = str.length(endTokenClean) >= 4
+endHourRaw = hasValidToken ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidToken ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+if windowStart
+    hasValidSessionEnd := hasValidToken and not na(endHourRaw) and not na(endMinuteRaw)
+    if hasValidSessionEnd
+        sessionEndHour := int(endHourRaw)
+        sessionEndMinute := int(endMinuteRaw)
+if inWindow and hasValidSessionEnd
+    currentTs = barstate.isrealtime ? timenow : time
+    currentMinuteOfDay = hour(currentTs, sessionTz) * 60 + minute(currentTs, sessionTz)
+    sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+    minutesToSessionEnd := sessionEndMinuteOfDay - currentMinuteOfDay
+else
+    minutesToSessionEnd := na
+withinCutoff = inWindow and hasValidSessionEnd and minutesToSessionEnd < cutOffMinutes
+allowNewEntry = inWindow and not withinCutoff and not tradedThisWindow
 
 trigger1Tf = "120"
 trigger2Tf = "60"
@@ -134,7 +145,7 @@ if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
     strategy.close_all(comment="Funky first flip exit", immediately=true)
 
 exitOnLossOfBG = exitOnLossMode == 1
-if inWindow and barstate.isnew and not tradedThisWindow and strategy.position_size == 0
+if allowNewEntry and barstate.isnew and strategy.position_size == 0
     if bgLong and not bgShort
         strategy.entry("Long", strategy.long, comment="BG Active Entry")
         tradedThisWindow := true
@@ -142,7 +153,7 @@ if inWindow and barstate.isnew and not tradedThisWindow and strategy.position_si
         strategy.entry("Short", strategy.short, comment="BG Active Entry")
         tradedThisWindow := true
 
-allowSignalEntry = allowNewEntry and not tradedThisWindow and strategy.position_size == 0
+allowSignalEntry = allowNewEntry and strategy.position_size == 0
 if allowSignalEntry and longFlipSignal
     strategy.entry("Long", strategy.long, comment="Flip Long")
     tradedThisWindow := true
@@ -166,4 +177,5 @@ if strategy.position_size < 0
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
 plotchar(tradedThisWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
 plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
-plotchar(withinCutoff, "withinCutoff", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
+plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
+plot(minutesToSessionEnd, "minutesToSessionEnd", color=color.new(color.white, 0), display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -123,8 +123,12 @@ alignLong = jmaLong and kernelBullish
 alignShort = jmaShort and kernelBearish
 bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
 bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
-bgLong15m = request.security(syminfo.tickerid, "15", bgLong[1], lookahead=barmerge.lookahead_off)
-bgShort15m = request.security(syminfo.tickerid, "15", bgShort[1], lookahead=barmerge.lookahead_off)
+bgLong15m = request.security(syminfo.tickerid, "15", bgLong, lookahead=barmerge.lookahead_off)
+bgShort15m = request.security(syminfo.tickerid, "15", bgShort, lookahead=barmerge.lookahead_off)
+barsSinceWindowStart = ta.barssince(windowStart)
+useBg15m = windowStart or (inWindow and barsSinceWindowStart <= 2)
+effectiveBgLong = useBg15m ? bgLong15m : bgLong
+effectiveBgShort = useBg15m ? bgShort15m : bgShort
 
 if not inWindow and strategy.position_size != 0
     strategy.close_all(comment="Window Close", immediately=true)
@@ -133,8 +137,8 @@ bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
 bgDirPrev = nz(bgDir[1], 0)
 flipToLong = inWindow and bgDir == 1 and bgDirPrev != 1
 flipToShort = inWindow and bgDir == -1 and bgDirPrev != -1
-longFlipSignal = flipToLong and not windowStart
-shortFlipSignal = flipToShort and not windowStart
+longFlipSignal = flipToLong and not windowStart and not useBg15m
+shortFlipSignal = flipToShort and not windowStart and not useBg15m
 
 var int firstCandleDir = 0
 var bool firstFlipSeen = false
@@ -151,10 +155,10 @@ if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
 
 exitOnLossOfBG = exitOnLossMode == 1
 if windowStart and not tradedThisWindow and not withinCutoff
-    if bgLong15m
+    if effectiveBgLong
         strategy.entry("Long", strategy.long, comment="AutoStart Long (from 15m)")
         tradedThisWindow := true
-    if bgShort15m
+    if effectiveBgShort
         strategy.entry("Short", strategy.short, comment="AutoStart Short (from 15m)")
         tradedThisWindow := true
 

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -1,0 +1,157 @@
+//@version=6
+strategy(
+    "SZT Background Edge Strategy (MGC 1m)",
+    shorttitle="SZT BG Edge",
+    overlay=true,
+    pyramiding=0,
+    default_qty_type=strategy.fixed,
+    default_qty_value=1,
+    calc_on_every_tick=false,
+    process_orders_on_close=false
+)
+
+import jdehorty/KernelFunctions/2 as kernels
+
+// ==============================
+// ===== Backtest controls ======
+// ==============================
+enforceOneMinute = input.bool(true, "Only Trade on 1m", group="Backtest")
+allowLongs = input.bool(true, "Enable Long Trades", group="Backtest")
+allowShorts = input.bool(true, "Enable Short Trades", group="Backtest")
+
+tradeSession = input.session("0815-0830", "Trading Window (HHMM-HHMM)", group="Session")
+sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"], group="Session")
+sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
+forceCloseOutsideWindow = input.bool(true, "Force Close Outside Window", group="Session")
+
+stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25, group="Risk")
+takeProfitPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25, group="Risk")
+
+// ==============================
+// ===== Signal components ======
+// ==============================
+trigger1Tf = input.timeframe("120", "Trigger 1 TF (2h)", group="Signal - Triggers")
+trigger2Tf = input.timeframe("60", "Trigger 2 TF (1h)", group="Signal - Triggers")
+trigger3Tf = input.timeframe("15", "Trigger 3 TF (15m)", group="Signal - Triggers")
+trigger4AtrAvgLen = input.int(15, "Trigger 4 ATR Avg Length", minval=1, group="Signal - Triggers")
+trigger4AtrMax = input.float(8.0, "Trigger 4 ATR Avg Max", minval=0.0, step=0.25, group="Signal - Triggers")
+triggerTimezoneMode = input.string("UTC-4 (fixed)", "Trigger Timezone", options=["UTC-4 (fixed)", "America/New_York (DST)", "Exchange"], group="Signal - Triggers")
+triggerTimezone = triggerTimezoneMode == "Exchange" ? syminfo.timezone : triggerTimezoneMode == "America/New_York (DST)" ? "America/New_York" : "Etc/GMT+4"
+
+kernel_h = input.int(4, "Kernel Lookback (h)", minval=2, group="Signal - Kernel")
+kernel_r = input.float(4.0, "Kernel Relative Weight (r)", step=0.5, group="Signal - Kernel")
+kernel_x = input.int(10, "Kernel Regression Level (x)", minval=2, group="Signal - Kernel")
+kernel_lag = input.int(1, "Kernel Lag", minval=1, maxval=3, group="Signal - Kernel")
+
+jmaLength = input.int(20, "JMA Length", minval=1, group="Signal - JMA")
+jmaPhase = input.int(40, "JMA Phase", minval=-100, maxval=100, group="Signal - JMA")
+jmaPower = input.int(2, "JMA Power", minval=1, maxval=5, group="Signal - JMA")
+
+cvdLength = input.int(14, "CVD Length", minval=1, group="Signal - CVD")
+cvdThreshold = input.float(10.0, "CVD Threshold", step=5.0, group="Signal - CVD")
+
+// ==============================
+// ===== Signal calculations =====
+// ==============================
+source = close
+
+t1 = time(trigger1Tf, "", triggerTimezone)
+t2 = time(trigger2Tf, "", triggerTimezone)
+t3 = time(trigger3Tf, "", triggerTimezone)
+var float trigger1Level = na
+var float trigger2Level = na
+var float trigger3Level = na
+trigger1Level := na(t1[1]) or t1 != t1[1] ? open : nz(trigger1Level[1], open)
+trigger2Level := na(t2[1]) or t2 != t2[1] ? open : nz(trigger2Level[1], open)
+trigger3Level := na(t3[1]) or t3 != t3[1] ? open : nz(trigger3Level[1], open)
+
+priceAboveAllTriggers = close > trigger1Level and close > trigger2Level and close > trigger3Level
+priceBelowAllTriggers = close < trigger1Level and close < trigger2Level and close < trigger3Level
+trigger1LongBias = close > trigger1Level
+trigger1ShortBias = close < trigger1Level
+trigger4AtrAvg = ta.atr(trigger4AtrAvgLen)
+trigger4VolatilityOk = trigger4AtrAvg <= trigger4AtrMax
+
+yhat1 = kernels.rationalQuadratic(source, kernel_h, kernel_r, kernel_x)
+kernelSmoothLookback = math.max(1, kernel_h - kernel_lag)
+yhat2 = kernels.gaussian(source, kernelSmoothLookback, kernel_x)
+kernelBullish = yhat2 >= yhat1
+kernelBearish = yhat2 <= yhat1
+
+phaseRatio = jmaPhase < -100 ? 0.5 : jmaPhase > 100 ? 2.5 : jmaPhase / 100 + 1.5
+beta = 0.45 * (jmaLength - 1) / (0.45 * (jmaLength - 1) + 2)
+alpha = math.pow(beta, jmaPower)
+var float jma = na
+var float e0 = na
+var float e1 = na
+var float e2 = na
+e0 := (1 - alpha) * source + alpha * nz(e0[1])
+e1 := (source - e0) * (1 - beta) + beta * nz(e1[1])
+e2 := (e0 + phaseRatio * e1 - nz(jma[1])) * math.pow(1 - alpha, 2) + math.pow(alpha, 2) * nz(e2[1])
+jma := e2 + nz(jma[1])
+
+jmaLong = jma > jma[1] and close > jma
+jmaShort = jma < jma[1] and close < jma
+
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = high - low
+bodyLength = spread - (upperWick + lowerWick)
+percentUpperWick = spread == 0.0 ? 0.0 : upperWick / spread
+percentLowerWick = spread == 0.0 ? 0.0 : lowerWick / spread
+percentBodyLength = spread == 0.0 ? 0.0 : bodyLength / spread
+buyingVolume = close > open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
+sellingVolume = close < open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
+cumulativeBuyingVolume = ta.ema(buyingVolume, cvdLength)
+cumulativeSellingVolume = ta.ema(sellingVolume, cvdLength)
+cvdDelta = cumulativeBuyingVolume - cumulativeSellingVolume
+cvdBullish = cvdDelta > cvdThreshold
+cvdBearish = cvdDelta < -cvdThreshold
+
+alignLong = jmaLong and kernelBullish
+alignShort = jmaShort and kernelBearish
+
+bgLong = barstate.isconfirmed and alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
+bgShort = barstate.isconfirmed and alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
+
+longSignalClose = bgLong and not bgLong[1]
+shortSignalClose = bgShort and not bgShort[1]
+
+// ==============================
+// ===== Execution logic =========
+// ==============================
+isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
+canTradeTf = not enforceOneMinute or isOneMinute
+inWindow = not na(time(timeframe.period, tradeSession, sessionTz))
+windowStart = inWindow and not inWindow[1]
+
+var bool tradedThisWindow = false
+if windowStart
+    tradedThisWindow := false
+
+flat = strategy.position_size == 0
+canSubmit = canTradeTf and inWindow and not tradedThisWindow and flat
+
+if canSubmit and allowLongs and longSignalClose and not shortSignalClose
+    strategy.entry("Long", strategy.long)
+    tradedThisWindow := true
+
+if canSubmit and allowShorts and shortSignalClose and not longSignalClose
+    strategy.entry("Short", strategy.short)
+    tradedThisWindow := true
+
+if strategy.position_size > 0
+    strategy.exit("Long Exit", "Long", stop=strategy.position_avg_price - stopPts, limit=strategy.position_avg_price + takeProfitPts)
+if strategy.position_size < 0
+    strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + stopPts, limit=strategy.position_avg_price - takeProfitPts)
+
+if forceCloseOutsideWindow and not inWindow and strategy.position_size != 0
+    strategy.close_all(comment="Window Close")
+
+// ==============================
+// ========= Visuals ============
+// ==============================
+bgcolor(bgLong ? color.new(color.teal, 86) : bgShort ? color.new(color.red, 86) : na, title="Signal Background")
+plotshape(longSignalClose, title="Long signal (close)", style=shape.circle, location=location.belowbar, size=size.tiny, color=color.new(color.teal, 0))
+plotshape(shortSignalClose, title="Short signal (close)", style=shape.circle, location=location.abovebar, size=size.tiny, color=color.new(color.red, 0))
+plot(jma, title="JMA", color=color.new(color.yellow, 0), linewidth=1)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -27,7 +27,7 @@ inWindow = isOneMinute and inWindowRaw
 firstBarOfWindow = inWindowRaw and na(time(timeframe.period, tradeSession, sessionTz)[1])
 windowStart = firstBarOfWindow
 var bool tradedThisWindow = false
-if barstate.isnew and not inWindow and inWindow[1]
+if not inWindow and inWindow[1]
     tradedThisWindow := false
 
 var int sessionEndHour = 0
@@ -124,9 +124,11 @@ alignShort = jmaShort and kernelBearish
 bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
 bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
 
+if not inWindow and strategy.position_size != 0
+    strategy.close_all(comment="Window Close", immediately=true)
+
 bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
 bgDirPrev = nz(bgDir[1], 0)
-
 flipToLong = inWindow and bgDir == 1 and bgDirPrev != 1
 flipToShort = inWindow and bgDir == -1 and bgDirPrev != -1
 longFlipSignal = flipToLong and not windowStart
@@ -146,12 +148,12 @@ if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
     strategy.close_all(comment="Funky first flip exit", immediately=true)
 
 exitOnLossOfBG = exitOnLossMode == 1
-if windowStart and not tradedThisWindow and not withinCutoff and strategy.position_size == 0
-    if bgLong or bgShort
-        if bgLong
-            strategy.entry("Long", strategy.long, comment="AutoStart Long")
-        if bgShort
-            strategy.entry("Short", strategy.short, comment="AutoStart Short")
+if windowStart and not tradedThisWindow and not withinCutoff
+    if bgLong
+        strategy.entry("Long", strategy.long, comment="AutoStart Long")
+        tradedThisWindow := true
+    if bgShort
+        strategy.entry("Short", strategy.short, comment="AutoStart Short")
         tradedThisWindow := true
 
 allowSignalEntry = allowNewEntry and not tradedThisWindow and strategy.position_size == 0
@@ -167,9 +169,6 @@ if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and no
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort
     strategy.close("Short", comment="Short BG Lost")
 
-if not inWindow and strategy.position_size != 0
-    strategy.close_all(comment="Window Close", immediately=true)
-
 if strategy.position_size > 0
     strategy.exit("Long Exit", "Long", stop=strategy.position_avg_price - stopPts, limit=strategy.position_avg_price + tpPts)
 if strategy.position_size < 0
@@ -178,5 +177,7 @@ if strategy.position_size < 0
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
 plotchar(tradedThisWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
 plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
+plotchar(windowStart, "windowStart", "", location.top, color=color.new(color.blue, 0), size=size.tiny, display=display.data_window)
+plotchar(bgLong, "bgLong (1er vela)", "", location.top, color=color.new(color.green, 0), size=size.tiny, display=display.data_window)
 plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
 plot(minutesToSessionEnd, "minutesToSessionEnd", color=color.new(color.white, 0), display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -18,7 +18,6 @@ cutOffMinutes = input.int(4, "Cut-Off (Minutes before close)", minval=1, maxval=
 stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25)
 tpPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25)
 exitOnLossMode = input.int(1, "Exit on BG Loss (1=Yes, 0=No)", minval=0, maxval=1, step=1)
-firstFlipMode = input.int(0, "Exit on First Candle Flip (1=Yes, 0=No)", minval=0, maxval=1, step=1)
 confirmationBars = input.int(3, "BG Confirmation Bars", minval=1, maxval=10, step=1)
 
 sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
@@ -139,27 +138,14 @@ if barstate.isconfirmed
             bgDirConfirmed := bgDir
             bgDirCounter := 0
 
-var int firstCandleDir = 0
-var bool firstFlipSeen = false
-if windowStart
-    firstCandleDir := bgDir
-    firstFlipSeen := false
-
-firstCandleFlipped = barstate.isconfirmed and inWindow and not windowStart and not firstFlipSeen and firstCandleDir != 0 and bgDir != firstCandleDir
-if firstCandleFlipped
-    firstFlipSeen := true
-
-if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
-    strategy.close_all(comment="Funky first flip exit", immediately=true)
-
 exitOnLossOfBG = exitOnLossMode == 1
-if windowStart and not tradedThisWindow and not withinCutoff
-    if bgDirConfirmed == 1
-        strategy.entry("Long", strategy.long, comment="AutoStart Long")
-        tradedThisWindow := true
-    if bgDirConfirmed == -1
-        strategy.entry("Short", strategy.short, comment="AutoStart Short")
-        tradedThisWindow := true
+if windowStart and not tradedThisWindow
+    if not withinCutoff
+        if bgDirConfirmed == 1
+            strategy.entry("Long", strategy.long, comment="AutoStart Long")
+        if bgDirConfirmed == -1
+            strategy.entry("Short", strategy.short, comment="AutoStart Short")
+    tradedThisWindow := true
 
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and bgDirConfirmed != 1
     strategy.close("Long", comment="Long BG Lost")

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -145,15 +145,15 @@ if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
     strategy.close_all(comment="Funky first flip exit", immediately=true)
 
 exitOnLossOfBG = exitOnLossMode == 1
-if allowNewEntry and barstate.isnew and strategy.position_size == 0
+if windowStart and not tradedThisWindow and not withinCutoff and strategy.position_size == 0
     if bgLong and not bgShort
-        strategy.entry("Long", strategy.long, comment="BG Active Entry")
+        strategy.entry("Long", strategy.long, comment="AutoStart Long")
         tradedThisWindow := true
     else if bgShort and not bgLong
-        strategy.entry("Short", strategy.short, comment="BG Active Entry")
+        strategy.entry("Short", strategy.short, comment="AutoStart Short")
         tradedThisWindow := true
 
-allowSignalEntry = allowNewEntry and strategy.position_size == 0
+allowSignalEntry = allowNewEntry and not tradedThisWindow and strategy.position_size == 0
 if allowSignalEntry and longFlipSignal
     strategy.entry("Long", strategy.long, comment="Flip Long")
     tradedThisWindow := true

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -27,7 +27,7 @@ cutOffMinutes = input.int(2, "Cut-Off (Minutes before close)", minval=1, maxval=
 // ==== CONFIG ESTRATEGIA =============
 // ====================================
 exitOnFirstFlip = input.bool(false, "Exit on First Candle Flip (Funky Mode)", group="Strategy")
-exitOnBgLoss = input.bool(true, "Close on Loss of BG", group="Strategy")
+exitOnLossOfBG = input.bool(true, "Exit when background is lost (Gray)", group="Strategy")
 
 // ====================================
 // ==== RISK MANAGEMENT (Puntos) ======
@@ -96,7 +96,7 @@ if exitOnFirstFlip and firstCandleFlipped and strategy.position_size != 0
 // ====================================
 // ==== ENTRADAS ======================
 // ====================================
-allowSignalEntry = allowNewEntry and (exitOnBgLoss or strategy.position_size == 0)
+allowSignalEntry = allowNewEntry and (exitOnLossOfBG or strategy.position_size == 0)
 
 if allowSignalEntry and longEntrySignal
     strategy.entry("Long", strategy.long, comment=autoStartLong ? "AutoStart Long" : "Flip Long")
@@ -107,13 +107,13 @@ if allowSignalEntry and shortEntrySignal
 // ====================================
 // ==== SALIDAS ESTÁNDAR ==============
 // ====================================
-tryingReverseToShort = exitOnBgLoss and allowSignalEntry and shortEntrySignal
-tryingReverseToLong = exitOnBgLoss and allowSignalEntry and longEntrySignal
+tryingReverseToShort = exitOnLossOfBG and allowSignalEntry and shortEntrySignal
+tryingReverseToLong = exitOnLossOfBG and allowSignalEntry and longEntrySignal
 
-if exitOnBgLoss and barConfirmed and strategy.position_size > 0 and not bgLong and not tryingReverseToShort
+if exitOnLossOfBG and barConfirmed and strategy.position_size > 0 and not bgLong and not tryingReverseToShort
     strategy.close("Long", comment="Long BG Lost")
 
-if exitOnBgLoss and barConfirmed and strategy.position_size < 0 and not bgShort and not tryingReverseToLong
+if exitOnLossOfBG and barConfirmed and strategy.position_size < 0 and not bgShort and not tryingReverseToLong
     strategy.close("Short", comment="Short BG Lost")
 
 if not inWindow and strategy.position_size != 0

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -164,5 +164,6 @@ if strategy.position_size < 0
     strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + stopPts, limit=strategy.position_avg_price - tpPts)
 
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
-plotchar(withinCutoff ? 1 : 0, "CutOff Active", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
-plotchar(tradedThisWindow ? 1 : 0, "Traded This Window", "", location.top, color=color.new(color.yellow, 0), size=size.tiny, display=display.data_window)
+plotchar(tradedThisWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
+plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
+plotchar(withinCutoff, "withinCutoff", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -25,6 +25,9 @@ isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
 inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
 inWindow = isOneMinute and inWindowRaw
 windowStart = inWindow and not inWindow[1]
+var bool tradedThisWindow = false
+if barstate.isnew and not inWindow and inWindow[1]
+    tradedThisWindow := false
 
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
 sessionRanges = str.split(sessionCore, ",")
@@ -114,10 +117,8 @@ bgDirPrev = nz(bgDir[1], 0)
 
 flipToLong = inWindow and bgDir == 1 and bgDirPrev != 1
 flipToShort = inWindow and bgDir == -1 and bgDirPrev != -1
-autoStartLong = windowStart and bgDir == 1
-autoStartShort = windowStart and bgDir == -1
-longEntrySignal = autoStartLong or (flipToLong and not windowStart)
-shortEntrySignal = autoStartShort or (flipToShort and not windowStart)
+longFlipSignal = flipToLong and not windowStart
+shortFlipSignal = flipToShort and not windowStart
 
 var int firstCandleDir = 0
 var bool firstFlipSeen = false
@@ -133,17 +134,25 @@ if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
     strategy.close_all(comment="Funky first flip exit", immediately=true)
 
 exitOnLossOfBG = exitOnLossMode == 1
-allowSignalEntry = allowNewEntry and (exitOnLossOfBG or strategy.position_size == 0)
-if allowSignalEntry and longEntrySignal
-    strategy.entry("Long", strategy.long, comment=autoStartLong ? "AutoStart Long" : "Flip Long")
-if allowSignalEntry and shortEntrySignal
-    strategy.entry("Short", strategy.short, comment=autoStartShort ? "AutoStart Short" : "Flip Short")
+if inWindow and barstate.isnew and not tradedThisWindow and strategy.position_size == 0
+    if bgLong and not bgShort
+        strategy.entry("Long", strategy.long, comment="BG Active Entry")
+        tradedThisWindow := true
+    else if bgShort and not bgLong
+        strategy.entry("Short", strategy.short, comment="BG Active Entry")
+        tradedThisWindow := true
 
-tryingReverseToShort = exitOnLossOfBG and allowSignalEntry and shortEntrySignal
-tryingReverseToLong = exitOnLossOfBG and allowSignalEntry and longEntrySignal
-if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong and not tryingReverseToShort
+allowSignalEntry = allowNewEntry and not tradedThisWindow and strategy.position_size == 0
+if allowSignalEntry and longFlipSignal
+    strategy.entry("Long", strategy.long, comment="Flip Long")
+    tradedThisWindow := true
+if allowSignalEntry and shortFlipSignal
+    strategy.entry("Short", strategy.short, comment="Flip Short")
+    tradedThisWindow := true
+
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong
     strategy.close("Long", comment="Long BG Lost")
-if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort and not tryingReverseToLong
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort
     strategy.close("Short", comment="Short BG Lost")
 
 if not inWindow and strategy.position_size != 0

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -1,5 +1,5 @@
 //@version=6
-strategy("SZT 15m Expanse", overlay=true, process_orders_on_close=false, calc_on_every_tick=true, pyramiding=0, default_qty_type=strategy.fixed, default_qty_value=1)
+strategy("SZT 15m Expanse", overlay=true, process_orders_on_close=false, calc_on_every_tick=true, pyramiding=0, initial_capital=100000, default_qty_type=strategy.fixed, default_qty_value=1)
 
 import jdehorty/KernelFunctions/2 as kernels
 

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -123,6 +123,8 @@ alignLong = jmaLong and kernelBullish
 alignShort = jmaShort and kernelBearish
 bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
 bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
+bgLong15m = request.security(syminfo.tickerid, "15", bgLong[1], lookahead=barmerge.lookahead_off)
+bgShort15m = request.security(syminfo.tickerid, "15", bgShort[1], lookahead=barmerge.lookahead_off)
 
 if not inWindow and strategy.position_size != 0
     strategy.close_all(comment="Window Close", immediately=true)
@@ -149,11 +151,11 @@ if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
 
 exitOnLossOfBG = exitOnLossMode == 1
 if windowStart and not tradedThisWindow and not withinCutoff
-    if bgLong
-        strategy.entry("Long", strategy.long, comment="AutoStart Long")
+    if bgLong15m
+        strategy.entry("Long", strategy.long, comment="AutoStart Long (from 15m)")
         tradedThisWindow := true
-    if bgShort
-        strategy.entry("Short", strategy.short, comment="AutoStart Short")
+    if bgShort15m
+        strategy.entry("Short", strategy.short, comment="AutoStart Short (from 15m)")
         tradedThisWindow := true
 
 allowSignalEntry = allowNewEntry and not tradedThisWindow and strategy.position_size == 0

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -1,51 +1,31 @@
 //@version=6
-strategy(
-    "SZT Master Strategy",
-    overlay=true,
-    pyramiding=0,
-    default_qty_type=strategy.fixed,
-    default_qty_value=1,
-    process_orders_on_close=false,
-    calc_on_every_tick=true
-)
+strategy("SZT Unificada OptiBro", overlay=true, process_orders_on_close=false, calc_on_every_tick=true, pyramiding=0, default_qty_type=strategy.fixed, default_qty_value=1)
 
-// ====================================
-// ==== SEÑAL EXTERNA (Background) ====
-// ====================================
-bgLongSource = input.source(close * 0.0, "BG Long Source", group="Signal")
-bgShortSource = input.source(close * 0.0, "BG Short Source", group="Signal")
-bgLong = nz(bgLongSource, 0.0) > 0.0
-bgShort = nz(bgShortSource, 0.0) > 0.0
+import jdehorty/KernelFunctions/2 as kernels
 
-// ====================================
-// ==== VENTANA + CUT OFF =============
-// ====================================
-tradeSession = input.session("0815-0830", "Trading Window", group="Session")
-sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"], group="Session")
+kernel_h = input.int(4, "Kernel Lookback (h)", minval=2, step=1)
+kernel_r = input.float(4.0, "Kernel Relative Weight (r)", step=0.5)
+kernel_x = input.int(10, "Kernel Regression Level (x)", minval=2, step=1)
+kernel_lag = input.int(1, "Kernel Lag", minval=1, maxval=3)
+jmaPhase = input.int(40, "JMA Phase", minval=-100, maxval=100, step=1)
+jmaPower = input.int(2, "JMA Power", minval=1, maxval=5)
+cvdLength = input.int(14, "CVD Length", minval=1, step=1)
+cvdThreshold = input.float(10.0, "CVD Threshold", step=5.0)
+
+tradeSession = input.session("0815-0830", "Trading Window")
+sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"])
+cutOffMinutes = input.int(2, "Cut-Off (Minutes before close)", minval=1, maxval=5)
+stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25)
+tpPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25)
+exitOnLossMode = input.int(1, "Exit on BG Loss (1=Yes, 0=No)", minval=0, maxval=1, step=1)
+firstFlipMode = input.int(0, "Exit on First Candle Flip (1=Yes, 0=No)", minval=0, maxval=1, step=1)
+
 sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
-cutOffMinutes = input.int(2, "Cut-Off (Minutes before close)", minval=1, maxval=5, group="Session")
-
-// ====================================
-// ==== CONFIG ESTRATEGIA =============
-// ====================================
-exitOnFirstFlip = input.bool(false, "Exit on First Candle Flip (Funky Mode)", group="Strategy")
-exitOnLossOfBG = input.bool(true, "Exit when background is lost (Gray)", group="Strategy")
-
-// ====================================
-// ==== RISK MANAGEMENT (Puntos) ======
-// ====================================
-stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25, group="Risk")
-tpPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25, group="Risk")
-
-// ====================================
-// ==== SESIÓN / TIEMPO ===============
-// ====================================
 isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
 inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
 inWindow = isOneMinute and inWindowRaw
 windowStart = inWindow and not inWindow[1]
 
-// Parse defensivo del fin de sesión para cálculo de cut-off.
 sessionCore = array.get(str.split(tradeSession, ":"), 0)
 sessionRanges = str.split(sessionCore, ",")
 lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ""
@@ -63,9 +43,72 @@ minutesToSessionEnd = sessionEndMinuteOfDay - barCloseMinuteOfDay
 withinCutoff = hasValidEnd and inWindow and minutesToSessionEnd < cutOffMinutes
 allowNewEntry = inWindow and not withinCutoff
 
-// ====================================
-// ==== DIRECCIÓN DEL BG ==============
-// ====================================
+trigger1Tf = "120"
+trigger2Tf = "60"
+trigger3Tf = "15"
+triggerTimezone = "Etc/GMT+4"
+trigger4AtrAvgLen = 15
+trigger4AtrMax = 8.0
+jmaLength = 20
+
+t1 = time(trigger1Tf, "", triggerTimezone)
+t2 = time(trigger2Tf, "", triggerTimezone)
+t3 = time(trigger3Tf, "", triggerTimezone)
+var float trigger1Level = na
+var float trigger2Level = na
+var float trigger3Level = na
+trigger1Level := na(t1[1]) or t1 != t1[1] ? open : nz(trigger1Level[1], open)
+trigger2Level := na(t2[1]) or t2 != t2[1] ? open : nz(trigger2Level[1], open)
+trigger3Level := na(t3[1]) or t3 != t3[1] ? open : nz(trigger3Level[1], open)
+
+priceAboveAllTriggers = close > trigger1Level and close > trigger2Level and close > trigger3Level
+priceBelowAllTriggers = close < trigger1Level and close < trigger2Level and close < trigger3Level
+trigger1LongBias = close > trigger1Level
+trigger1ShortBias = close < trigger1Level
+trigger4AtrAvg = ta.atr(trigger4AtrAvgLen)
+trigger4VolatilityOk = trigger4AtrAvg <= trigger4AtrMax
+
+source = close
+yhat1 = kernels.rationalQuadratic(source, kernel_h, kernel_r, kernel_x)
+kernelSmoothLookback = math.max(1, kernel_h - kernel_lag)
+yhat2 = kernels.gaussian(source, kernelSmoothLookback, kernel_x)
+kernelBullish = yhat2 >= yhat1
+kernelBearish = yhat2 <= yhat1
+
+phaseRatio = jmaPhase < -100 ? 0.5 : jmaPhase > 100 ? 2.5 : jmaPhase / 100 + 1.5
+beta = 0.45 * (jmaLength - 1) / (0.45 * (jmaLength - 1) + 2)
+alpha = math.pow(beta, jmaPower)
+var float jma = na
+var float e0 = na
+var float e1 = na
+var float e2 = na
+e0 := (1 - alpha) * source + alpha * nz(e0[1])
+e1 := (source - e0) * (1 - beta) + beta * nz(e1[1])
+e2 := (e0 + phaseRatio * e1 - nz(jma[1])) * math.pow(1 - alpha, 2) + math.pow(alpha, 2) * nz(e2[1])
+jma := e2 + nz(jma[1])
+jmaLong = jma > jma[1] and close > jma
+jmaShort = jma < jma[1] and close < jma
+
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpperWick = upperWick / spread
+percentLowerWick = lowerWick / spread
+percentBodyLength = bodyLength / spread
+buyingVolume = close > open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
+sellingVolume = close < open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
+cumulativeBuyingVolume = ta.ema(buyingVolume, cvdLength)
+cumulativeSellingVolume = ta.ema(sellingVolume, cvdLength)
+cvdDelta = cumulativeBuyingVolume - cumulativeSellingVolume
+cvdBullish = cvdDelta > cvdThreshold
+cvdBearish = cvdDelta < -cvdThreshold
+
+alignLong = jmaLong and kernelBullish
+alignShort = jmaShort and kernelBearish
+bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
+bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
+
 bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
 bgDirPrev = nz(bgDir[1], 0)
 
@@ -73,16 +116,11 @@ flipToLong = inWindow and bgDir == 1 and bgDirPrev != 1
 flipToShort = inWindow and bgDir == -1 and bgDirPrev != -1
 autoStartLong = windowStart and bgDir == 1
 autoStartShort = windowStart and bgDir == -1
-
 longEntrySignal = autoStartLong or (flipToLong and not windowStart)
 shortEntrySignal = autoStartShort or (flipToShort and not windowStart)
 
-// ====================================
-// ==== FIRST-CANDLE FLIP (FUNKY) =====
-// ====================================
 var int firstCandleDir = 0
 var bool firstFlipSeen = false
-
 if windowStart
     firstCandleDir := bgDir
     firstFlipSeen := false
@@ -91,45 +129,30 @@ firstCandleFlipped = barstate.isconfirmed and inWindow and not windowStart and n
 if firstCandleFlipped
     firstFlipSeen := true
 
-if exitOnFirstFlip and firstCandleFlipped and strategy.position_size != 0
+if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
     strategy.close_all(comment="Funky first flip exit", immediately=true)
 
-// ====================================
-// ==== ENTRADAS ======================
-// ====================================
+exitOnLossOfBG = exitOnLossMode == 1
 allowSignalEntry = allowNewEntry and (exitOnLossOfBG or strategy.position_size == 0)
-
 if allowSignalEntry and longEntrySignal
     strategy.entry("Long", strategy.long, comment=autoStartLong ? "AutoStart Long" : "Flip Long")
-
 if allowSignalEntry and shortEntrySignal
     strategy.entry("Short", strategy.short, comment=autoStartShort ? "AutoStart Short" : "Flip Short")
 
-// ====================================
-// ==== SALIDAS ESTÁNDAR ==============
-// ====================================
 tryingReverseToShort = exitOnLossOfBG and allowSignalEntry and shortEntrySignal
 tryingReverseToLong = exitOnLossOfBG and allowSignalEntry and longEntrySignal
-
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong and not tryingReverseToShort
     strategy.close("Long", comment="Long BG Lost")
-
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort and not tryingReverseToLong
     strategy.close("Short", comment="Short BG Lost")
 
 if not inWindow and strategy.position_size != 0
     strategy.close_all(comment="Window Close", immediately=true)
 
-// ====================================
-// ==== SL / TP FIJOS EN PUNTOS =======
-// ====================================
 if strategy.position_size > 0
     strategy.exit("Long Exit", "Long", stop=strategy.position_avg_price - stopPts, limit=strategy.position_avg_price + tpPts)
 if strategy.position_size < 0
     strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + stopPts, limit=strategy.position_avg_price - tpPts)
 
-// ====================================
-// ==== VISUAL ========================
-// ====================================
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
 plotchar(withinCutoff ? 1 : 0, "CutOff Active", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -9,7 +9,7 @@ jmaPhase = input.int(40, "JMA Phase", minval=-100, maxval=100, step=1)
 jmaPower = input.int(2, "JMA Power", minval=1, maxval=5)
 cvdLength = input.int(14, "CVD Length", minval=1, step=1)
 cvdThreshold = input.float(10.0, "CVD Threshold", step=5.0)
-tradeSession = input.session("0815-0830", "Trading Window")
+tradeSession = input.session("0800-0900", "Global Trading Window")
 sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"])
 cutOffMinutes = input.int(4, "Cut-Off (Minutes before close)", minval=1, maxval=5)
 stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25)
@@ -20,10 +20,14 @@ sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
 isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
 inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
 inWindow = isOneMinute and inWindowRaw
-windowStart = inWindow and not inWindow[1]
-var bool tradedThisWindow = false
+subWindowTime = time("15", "", sessionTz)
+isNew15mBar = na(subWindowTime[1]) or subWindowTime != subWindowTime[1]
+windowStart = inWindow and isNew15mBar
+var bool tradedThisSubWindow = false
+if barstate.isnew and windowStart
+    tradedThisSubWindow := false
 if barstate.isnew and not inWindow and inWindow[1]
-    tradedThisWindow := false
+    tradedThisSubWindow := false
 var int sessionEndHour = 0
 var int sessionEndMinute = 0
 var float minutesToSessionEnd = na
@@ -50,7 +54,7 @@ if inWindow and hasValidSessionEnd
 else
     minutesToSessionEnd := na
 withinCutoff = inWindow and hasValidSessionEnd and minutesToSessionEnd < cutOffMinutes
-allowNewEntry = inWindow and not withinCutoff and not tradedThisWindow
+allowNewEntry = inWindow and not withinCutoff and not tradedThisSubWindow
 trigger1Tf = "120"
 trigger2Tf = "60"
 trigger3Tf = "15"
@@ -127,20 +131,20 @@ if firstCandleFlipped
 if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
     strategy.close_all(comment="Funky first flip exit", immediately=true)
 exitOnLossOfBG = exitOnLossMode == 1
-if windowStart and not tradedThisWindow and not withinCutoff and strategy.position_size == 0
+if windowStart and not tradedThisSubWindow and not withinCutoff and strategy.position_size == 0
     if bgLong and not bgShort
         strategy.entry("Long", strategy.long, comment="AutoStart Long")
-        tradedThisWindow := true
+        tradedThisSubWindow := true
     else if bgShort and not bgLong
         strategy.entry("Short", strategy.short, comment="AutoStart Short")
-        tradedThisWindow := true
-allowSignalEntry = allowNewEntry and not tradedThisWindow and strategy.position_size == 0
+        tradedThisSubWindow := true
+allowSignalEntry = allowNewEntry and not tradedThisSubWindow and strategy.position_size == 0
 if allowSignalEntry and longFlipSignal
     strategy.entry("Long", strategy.long, comment="Flip Long")
-    tradedThisWindow := true
+    tradedThisSubWindow := true
 if allowSignalEntry and shortFlipSignal
     strategy.entry("Short", strategy.short, comment="Flip Short")
-    tradedThisWindow := true
+    tradedThisSubWindow := true
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong
     strategy.close("Long", comment="Long BG Lost")
 if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort
@@ -154,7 +158,7 @@ if strategy.position_size > 0
 if strategy.position_size < 0
     strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + stopPts, limit=strategy.position_avg_price - tpPts)
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
-plotchar(tradedThisWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
+plotchar(tradedThisSubWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
 plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
 plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
 plot(minutesToSessionEnd, "minutesToSessionEnd", color=color.new(color.white, 0), display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -27,6 +27,7 @@ cutOffMinutes = input.int(2, "Cut-Off (Minutes before close)", minval=1, maxval=
 // ==== CONFIG ESTRATEGIA =============
 // ====================================
 exitOnFirstFlip = input.bool(false, "Exit on First Candle Flip (Funky Mode)", group="Strategy")
+exitOnBgLoss = input.bool(true, "Close on Loss of BG", group="Strategy")
 
 // ====================================
 // ==== RISK MANAGEMENT (Puntos) ======
@@ -95,22 +96,24 @@ if exitOnFirstFlip and firstCandleFlipped and strategy.position_size != 0
 // ====================================
 // ==== ENTRADAS ======================
 // ====================================
-if allowNewEntry and longEntrySignal
+allowSignalEntry = allowNewEntry and (exitOnBgLoss or strategy.position_size == 0)
+
+if allowSignalEntry and longEntrySignal
     strategy.entry("Long", strategy.long, comment=autoStartLong ? "AutoStart Long" : "Flip Long")
 
-if allowNewEntry and shortEntrySignal
+if allowSignalEntry and shortEntrySignal
     strategy.entry("Short", strategy.short, comment=autoStartShort ? "AutoStart Short" : "Flip Short")
 
 // ====================================
 // ==== SALIDAS ESTÁNDAR ==============
 // ====================================
-tryingReverseToShort = allowNewEntry and shortEntrySignal
-tryingReverseToLong = allowNewEntry and longEntrySignal
+tryingReverseToShort = exitOnBgLoss and allowSignalEntry and shortEntrySignal
+tryingReverseToLong = exitOnBgLoss and allowSignalEntry and longEntrySignal
 
-if barConfirmed and strategy.position_size > 0 and not bgLong and not tryingReverseToShort
+if exitOnBgLoss and barConfirmed and strategy.position_size > 0 and not bgLong and not tryingReverseToShort
     strategy.close("Long", comment="Long BG Lost")
 
-if barConfirmed and strategy.position_size < 0 and not bgShort and not tryingReverseToLong
+if exitOnBgLoss and barConfirmed and strategy.position_size < 0 and not bgShort and not tryingReverseToLong
     strategy.close("Short", comment="Short BG Lost")
 
 if not inWindow and strategy.position_size != 0

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -20,8 +20,7 @@ sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
 isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
 inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
 inWindow = isOneMinute and inWindowRaw
-_15mTime = time("15", "", sessionTz)
-isNew15mBar = not na(_15mTime) and na(_15mTime[1])
+isNew15mBar = timeframe.isminutes and timeframe.multiplier == 15 and barstate.isnew
 windowStart = inWindow and isNew15mBar
 var bool tradedThisWindow = false
 if windowStart

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -1,8 +1,6 @@
 //@version=6
-strategy("SZT 15m Expanse", overlay=true, process_orders_on_close=false, calc_on_every_tick=true, pyramiding=0, initial_capital=100000, default_qty_type=strategy.fixed, default_qty_value=1)
-
+strategy("SZT 15m Expanse", overlay=true, process_orders_on_close=false, calc_on_every_tick=true, pyramiding=0, default_qty_type=strategy.fixed, default_qty_value=1)
 import jdehorty/KernelFunctions/2 as kernels
-
 kernel_h = input.int(4, "Kernel Lookback (h)", minval=2, step=1)
 kernel_r = input.float(4.0, "Kernel Relative Weight (r)", step=0.5)
 kernel_x = input.int(10, "Kernel Regression Level (x)", minval=2, step=1)
@@ -11,25 +9,21 @@ jmaPhase = input.int(40, "JMA Phase", minval=-100, maxval=100, step=1)
 jmaPower = input.int(2, "JMA Power", minval=1, maxval=5)
 cvdLength = input.int(14, "CVD Length", minval=1, step=1)
 cvdThreshold = input.float(10.0, "CVD Threshold", step=5.0)
-
 tradeSession = input.session("0815-0830", "Trading Window")
 sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"])
 cutOffMinutes = input.int(4, "Cut-Off (Minutes before close)", minval=1, maxval=5)
 stopPts = input.float(5.0, "Stop Loss (Points)", minval=0.25, step=0.25)
 tpPts = input.float(10.0, "Take Profit (Points)", minval=0.25, step=0.25)
 exitOnLossMode = input.int(1, "Exit on BG Loss (1=Yes, 0=No)", minval=0, maxval=1, step=1)
-confirmationBars = input.int(3, "BG Confirmation Bars", minval=1, maxval=10, step=1)
-
+firstFlipMode = input.int(0, "Exit on First Candle Flip (1=Yes, 0=No)", minval=0, maxval=1, step=1)
 sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
 isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
 inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
 inWindow = isOneMinute and inWindowRaw
-firstBarOfWindow = inWindowRaw and na(time(timeframe.period, tradeSession, sessionTz)[1])
-windowStart = firstBarOfWindow
+windowStart = inWindow and not inWindow[1]
 var bool tradedThisWindow = false
-if not inWindow and inWindow[1]
+if barstate.isnew and not inWindow and inWindow[1]
     tradedThisWindow := false
-
 var int sessionEndHour = 0
 var int sessionEndMinute = 0
 var float minutesToSessionEnd = na
@@ -56,7 +50,7 @@ if inWindow and hasValidSessionEnd
 else
     minutesToSessionEnd := na
 withinCutoff = inWindow and hasValidSessionEnd and minutesToSessionEnd < cutOffMinutes
-
+allowNewEntry = inWindow and not withinCutoff and not tradedThisWindow
 trigger1Tf = "120"
 trigger2Tf = "60"
 trigger3Tf = "15"
@@ -64,7 +58,6 @@ triggerTimezone = "Etc/GMT+4"
 trigger4AtrAvgLen = 15
 trigger4AtrMax = 8.0
 jmaLength = 20
-
 t1 = time(trigger1Tf, "", triggerTimezone)
 t2 = time(trigger2Tf, "", triggerTimezone)
 t3 = time(trigger3Tf, "", triggerTimezone)
@@ -74,21 +67,18 @@ var float trigger3Level = na
 trigger1Level := na(t1[1]) or t1 != t1[1] ? open : nz(trigger1Level[1], open)
 trigger2Level := na(t2[1]) or t2 != t2[1] ? open : nz(trigger2Level[1], open)
 trigger3Level := na(t3[1]) or t3 != t3[1] ? open : nz(trigger3Level[1], open)
-
 priceAboveAllTriggers = close > trigger1Level and close > trigger2Level and close > trigger3Level
 priceBelowAllTriggers = close < trigger1Level and close < trigger2Level and close < trigger3Level
 trigger1LongBias = close > trigger1Level
 trigger1ShortBias = close < trigger1Level
 trigger4AtrAvg = ta.atr(trigger4AtrAvgLen)
 trigger4VolatilityOk = trigger4AtrAvg <= trigger4AtrMax
-
 source = close
 yhat1 = kernels.rationalQuadratic(source, kernel_h, kernel_r, kernel_x)
 kernelSmoothLookback = math.max(1, kernel_h - kernel_lag)
 yhat2 = kernels.gaussian(source, kernelSmoothLookback, kernel_x)
 kernelBullish = yhat2 >= yhat1
 kernelBearish = yhat2 <= yhat1
-
 phaseRatio = jmaPhase < -100 ? 0.5 : jmaPhase > 100 ? 2.5 : jmaPhase / 100 + 1.5
 beta = 0.45 * (jmaLength - 1) / (0.45 * (jmaLength - 1) + 2)
 alpha = math.pow(beta, jmaPower)
@@ -102,7 +92,6 @@ e2 := (e0 + phaseRatio * e1 - nz(jma[1])) * math.pow(1 - alpha, 2) + math.pow(al
 jma := e2 + nz(jma[1])
 jmaLong = jma > jma[1] and close > jma
 jmaShort = jma < jma[1] and close < jma
-
 upperWick = close > open ? high - close : high - open
 lowerWick = close > open ? open - low : close - low
 spread = math.max(high - low, syminfo.mintick)
@@ -117,51 +106,55 @@ cumulativeSellingVolume = ta.ema(sellingVolume, cvdLength)
 cvdDelta = cumulativeBuyingVolume - cumulativeSellingVolume
 cvdBullish = cvdDelta > cvdThreshold
 cvdBearish = cvdDelta < -cvdThreshold
-
 alignLong = jmaLong and kernelBullish
 alignShort = jmaShort and kernelBearish
 bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
 bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
-
-if not inWindow and strategy.position_size != 0
-    strategy.close_all(comment="Window Close", immediately=true)
-
 bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
-var int bgDirConfirmed = 0
-var int bgDirCounter = 0
-if barstate.isconfirmed
-    if bgDir == bgDirConfirmed
-        bgDirCounter := 0
-    else
-        bgDirCounter := bgDir == nz(bgDir[1], 0) ? bgDirCounter + 1 : 1
-        if bgDirCounter >= confirmationBars
-            bgDirConfirmed := bgDir
-            bgDirCounter := 0
-
+bgDirPrev = nz(bgDir[1], 0)
+flipToLong = inWindow and bgDir == 1 and bgDirPrev != 1
+flipToShort = inWindow and bgDir == -1 and bgDirPrev != -1
+longFlipSignal = flipToLong and not windowStart
+shortFlipSignal = flipToShort and not windowStart
+var int firstCandleDir = 0
+var bool firstFlipSeen = false
+if windowStart
+    firstCandleDir := bgDir
+    firstFlipSeen := false
+firstCandleFlipped = barstate.isconfirmed and inWindow and not windowStart and not firstFlipSeen and firstCandleDir != 0 and bgDir != firstCandleDir
+if firstCandleFlipped
+    firstFlipSeen := true
+if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
+    strategy.close_all(comment="Funky first flip exit", immediately=true)
 exitOnLossOfBG = exitOnLossMode == 1
-if windowStart and not tradedThisWindow and not withinCutoff
-    if bgDir == 1
+if windowStart and not tradedThisWindow and not withinCutoff and strategy.position_size == 0
+    if bgLong and not bgShort
         strategy.entry("Long", strategy.long, comment="AutoStart Long")
         tradedThisWindow := true
-    if bgDir == -1
+    else if bgShort and not bgLong
         strategy.entry("Short", strategy.short, comment="AutoStart Short")
         tradedThisWindow := true
-
-if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and bgDirConfirmed != 1
+allowSignalEntry = allowNewEntry and not tradedThisWindow and strategy.position_size == 0
+if allowSignalEntry and longFlipSignal
+    strategy.entry("Long", strategy.long, comment="Flip Long")
+    tradedThisWindow := true
+if allowSignalEntry and shortFlipSignal
+    strategy.entry("Short", strategy.short, comment="Flip Short")
+    tradedThisWindow := true
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong
     strategy.close("Long", comment="Long BG Lost")
-if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and bgDirConfirmed != -1
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort
     strategy.close("Short", comment="Short BG Lost")
-
+barsSinceWindowStart = ta.barssince(windowStart)
+isLastWindowBar = inWindow and barsSinceWindowStart == 14
+if isLastWindowBar and strategy.position_size != 0
+    strategy.close_all(comment="Window Close (last bar)", immediately=true)
 if strategy.position_size > 0
     strategy.exit("Long Exit", "Long", stop=strategy.position_avg_price - stopPts, limit=strategy.position_avg_price + tpPts)
 if strategy.position_size < 0
     strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + stopPts, limit=strategy.position_avg_price - tpPts)
-
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
 plotchar(tradedThisWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
 plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
-plotchar(windowStart, "windowStart", "", location.top, color=color.new(color.blue, 0), size=size.tiny, display=display.data_window)
-plotchar(bgLong, "bgLong (1er vela)", "", location.top, color=color.new(color.green, 0), size=size.tiny, display=display.data_window)
-plotchar(bgDirConfirmed, "bgDirConfirmed", "", location.top, color=color.new(color.purple, 0), size=size.tiny, display=display.data_window)
 plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
 plot(minutesToSessionEnd, "minutesToSessionEnd", color=color.new(color.white, 0), display=display.data_window)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- refactor `SZT_15m_Expanse_OpenImpulse.pine` from strict all-conditions-AND gating to a score-based signal model to increase trade frequency while preserving base structure

## Implemented changes
### 1) Replace binary AND signal with score model
- add optimizable input:
  - `minScore = input.int(3, "Min Score", minval=1, maxval=5)`
- compute score components:
  - `longScore` = alignLong + cvdBullish + priceAboveAllTriggers + trigger1LongBias + trigger4VolatilityOk
  - `shortScore` = alignShort + cvdBearish + priceBelowAllTriggers + trigger1ShortBias + trigger4VolatilityOk
- redefine signals:
  - `bgLong = longScore >= minScore and longScore > shortScore`
  - `bgShort = shortScore >= minScore and shortScore > longScore`

### 2) Entry logic per 15m block (continuous evaluation)
- no first-minute-only trigger
- no `bgDir[1]`
- evaluate continuously inside block:
  - if `inWindow and not withinCutoff and not tradedThisSubWindow and strategy.position_size == 0`
    - first valid `bgLong/bgShort` takes the trade
    - lock sub-window via `tradedThisSubWindow := true`

### 3) Keep requested components intact
- session filters
- cutoff
- one-trade-per-sub-window gate
- SL/TP exits
- exit on BG loss
- no flip logic

## Result
- higher signal availability due to score thresholding
- deterministic one-trade-per-15m-sub-window behavior
- preserves core risk/session behavior while improving fill frequency
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7399a935-cb98-4f45-a79b-41cbafcb0e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7399a935-cb98-4f45-a79b-41cbafcb0e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

