### PR TITLE
Add modular Pine v6 futures strategy with ATR-based dynamic risk

### DIFF
--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -13,14 +13,12 @@ tradeSession = input.session("0800-0900", "Global Trading Window")
 sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"])
 cutOffMinutes = input.int(4, "Cut-Off (Minutes before close)", minval=1, maxval=5)
 
-// ==== Volatility Risk Manager ====
-atrLength = input.int(14, "ATR Length", minval=5)
-lowVolThreshold = input.float(10.0, "Low Volatility Threshold (points)", step=1.0)
-highVolThreshold = input.float(25.0, "High Volatility Threshold (points)", step=1.0)
-lowVolSLMult = input.float(1.2, "Low Vol Stop Multiplier", step=0.1)
-normVolSLMult = input.float(1.8, "Normal Vol Stop Multiplier", step=0.1)
-highVolSLMult = input.float(2.5, "High Vol Stop Multiplier", step=0.1)
-rrRatio = input.float(2.5, "Risk/Reward Ratio (TP = SL * R:R)", step=0.25)
+// ==== Volatility Stop ====
+useVolStop = input.bool(true, "Use Volatility Stop", group="Volatility Stop")
+vsLength = input.int(20, "ATR Length", minval=2, group="Volatility Stop")
+vsFactor = input.float(2.0, "ATR Multiplier", step=0.25, group="Volatility Stop")
+stopPts = input.float(25.0, "Initial Stop (Points)", step=5.0, group="Volatility Stop")
+tpMultiplier = input.float(3.0, "TP Multiplier (x Initial Stop)", step=0.5, group="Volatility Stop")
 
 exitOnLossMode = input.int(1, "Exit on BG Loss (1=Yes, 0=No)", minval=0, maxval=1, step=1)
 firstFlipMode = input.int(0, "Exit on First Candle Flip (1=Yes, 0=No)", minval=0, maxval=1, step=1)
@@ -162,28 +160,47 @@ isLastWindowBar = inWindow and barsSinceWindowStart == 14
 if isLastWindowBar and strategy.position_size != 0
     strategy.close_all(comment="Window Close (last bar)", immediately=true)
 
-atrValue = ta.atr(atrLength)
-isLowVol = atrValue < lowVolThreshold
-isHighVol = atrValue >= highVolThreshold
-isNormalVol = not isLowVol and not isHighVol
-slMult = isLowVol ? lowVolSLMult : isHighVol ? highVolSLMult : normVolSLMult
-tpMult = slMult * rrRatio
+volStop(src, atrlen, atrmult) =>
+    if not na(src)
+        var float regimeMax = src
+        var float regimeMin = src
+        var bool uptrend = true
+        var float stop = na
+        atrM = ta.atr(atrlen) * atrmult
+        regimeMax := math.max(regimeMax, src)
+        regimeMin := math.min(regimeMin, src)
+        stop := nz(uptrend ? math.max(stop, regimeMax - atrM) : math.min(stop, regimeMin + atrM), src)
+        uptrend := src - stop >= 0.0
+        prevUp = bar_index > 0 ? uptrend[1] : true
+        if uptrend != prevUp
+            regimeMax := src
+            regimeMin := src
+            stop := uptrend ? regimeMax - atrM : regimeMin + atrM
+        [stop, uptrend]
+
+[vsStop, vsUp] = volStop(close, vsLength, vsFactor)
+vsColor = vsUp ? color.new(#09d647, 0) : color.new(#8f8b8a, 0)
+tpPoints = stopPts * tpMultiplier
+
+float trailStopLong = na
+float trailStopShort = na
+float longLimit = na
+float shortLimit = na
 
 if strategy.position_size > 0
-    strategy.exit("Long Exit", "Long", stop=strategy.position_avg_price - (atrValue * slMult), limit=strategy.position_avg_price + (atrValue * tpMult))
-if strategy.position_size < 0
-    strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + (atrValue * slMult), limit=strategy.position_avg_price - (atrValue * tpMult))
+    initialStopLong = strategy.position_avg_price - stopPts
+    trailStopLong := useVolStop ? math.max(initialStopLong, vsStop) : initialStopLong
+    longLimit := strategy.position_avg_price + tpPoints
+    strategy.exit("Long Exit", "Long", stop=trailStopLong, limit=longLimit)
 
-longVolStop = strategy.position_size > 0 ? strategy.position_avg_price - (atrValue * slMult) : na
-longVolTp = strategy.position_size > 0 ? strategy.position_avg_price + (atrValue * tpMult) : na
-shortVolStop = strategy.position_size < 0 ? strategy.position_avg_price + (atrValue * slMult) : na
-shortVolTp = strategy.position_size < 0 ? strategy.position_avg_price - (atrValue * tpMult) : na
+if strategy.position_size < 0
+    initialStopShort = strategy.position_avg_price + stopPts
+    trailStopShort := useVolStop ? math.min(initialStopShort, vsStop) : initialStopShort
+    shortLimit := strategy.position_avg_price - tpPoints
+    strategy.exit("Short Exit", "Short", stop=trailStopShort, limit=shortLimit)
 
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
-plot(longVolStop, "Long Vol Stop", color=color.new(color.red, 0), linewidth=2, style=plot.style_linebr)
-plot(longVolTp, "Long Vol TP", color=color.new(color.lime, 0), linewidth=2, style=plot.style_linebr)
-plot(shortVolStop, "Short Vol Stop", color=color.new(color.red, 0), linewidth=2, style=plot.style_linebr)
-plot(shortVolTp, "Short Vol TP", color=color.new(color.lime, 0), linewidth=2, style=plot.style_linebr)
+plot(useVolStop and strategy.position_size != 0 ? (strategy.position_size > 0 ? trailStopLong : strategy.position_size < 0 ? trailStopShort : na) : na, title="Dynamic Stop", color=vsColor, linewidth=2, style=plot.style_linebr)
 plotchar(tradedThisSubWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
 plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
 plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -179,7 +179,3 @@ plotchar(tradedThisSubWindow, "tradedThisWindow", "", location.top, color=color.
 plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
 plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
 plot(minutesToSessionEnd, "minutesToSessionEnd", color=color.new(color.white, 0), display=display.data_window)
-plot(atrValue, "atrValue", color=color.new(color.yellow, 0), display=display.data_window)
-plotchar(isLowVol, "isLowVol", "", location.top, color=color.new(color.aqua, 0), size=size.tiny, display=display.data_window)
-plotchar(isNormalVol, "isNormalVol", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
-plotchar(isHighVol, "isHighVol", "", location.top, color=color.new(color.purple, 0), size=size.tiny, display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -174,7 +174,16 @@ if strategy.position_size > 0
 if strategy.position_size < 0
     strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + (atrValue * slMult), limit=strategy.position_avg_price - (atrValue * tpMult))
 
+longVolStop = strategy.position_size > 0 ? strategy.position_avg_price - (atrValue * slMult) : na
+longVolTp = strategy.position_size > 0 ? strategy.position_avg_price + (atrValue * tpMult) : na
+shortVolStop = strategy.position_size < 0 ? strategy.position_avg_price + (atrValue * slMult) : na
+shortVolTp = strategy.position_size < 0 ? strategy.position_avg_price - (atrValue * tpMult) : na
+
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
+plot(longVolStop, "Long Vol Stop", color=color.new(color.red, 0), linewidth=2, style=plot.style_linebr)
+plot(longVolTp, "Long Vol TP", color=color.new(color.lime, 0), linewidth=2, style=plot.style_linebr)
+plot(shortVolStop, "Short Vol Stop", color=color.new(color.red, 0), linewidth=2, style=plot.style_linebr)
+plot(shortVolTp, "Short Vol TP", color=color.new(color.lime, 0), linewidth=2, style=plot.style_linebr)
 plotchar(tradedThisSubWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
 plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
 plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -14,7 +14,6 @@ sessionTimezone = input.string("America/New_York", "Session Timezone", options=[
 cutOffMinutes = input.int(4, "Cut-Off (Minutes before close)", minval=1, maxval=5)
 
 // ==== Volatility Stop ====
-useVolStop = input.bool(true, "Use Volatility Stop", group="Volatility Stop")
 vsLength = input.int(20, "ATR Length", minval=2, group="Volatility Stop")
 vsFactor = input.float(2.0, "ATR Multiplier", step=0.25, group="Volatility Stop")
 stopPts = input.float(25.0, "Initial Stop (Points)", step=5.0, group="Volatility Stop")
@@ -189,18 +188,18 @@ float shortLimit = na
 
 if strategy.position_size > 0
     initialStopLong = strategy.position_avg_price - stopPts
-    trailStopLong := useVolStop ? math.max(initialStopLong, vsStop) : initialStopLong
+    trailStopLong := math.max(initialStopLong, vsStop)
     longLimit := strategy.position_avg_price + tpPoints
     strategy.exit("Long Exit", "Long", stop=trailStopLong, limit=longLimit)
 
 if strategy.position_size < 0
     initialStopShort = strategy.position_avg_price + stopPts
-    trailStopShort := useVolStop ? math.min(initialStopShort, vsStop) : initialStopShort
+    trailStopShort := math.min(initialStopShort, vsStop)
     shortLimit := strategy.position_avg_price - tpPoints
     strategy.exit("Short Exit", "Short", stop=trailStopShort, limit=shortLimit)
 
 bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
-plot(useVolStop and strategy.position_size != 0 ? (strategy.position_size > 0 ? trailStopLong : strategy.position_size < 0 ? trailStopShort : na) : na, title="Dynamic Stop", color=vsColor, linewidth=2, style=plot.style_linebr)
+plot(strategy.position_size != 0 ? (strategy.position_size > 0 ? trailStopLong : strategy.position_size < 0 ? trailStopShort : na) : na, title="Dynamic Stop", color=vsColor, linewidth=2, style=plot.style_linebr)
 plotchar(tradedThisSubWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
 plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
 plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)

--- a/SZT_Background_Edge_MGC_1m_Strategy.pine
+++ b/SZT_Background_Edge_MGC_1m_Strategy.pine
@@ -1,0 +1,185 @@
+//@version=6
+strategy("SZT 15m Expanse", overlay=true, process_orders_on_close=false, calc_on_every_tick=true, pyramiding=0, default_qty_type=strategy.fixed, default_qty_value=1)
+import jdehorty/KernelFunctions/2 as kernels
+kernel_h = input.int(4, "Kernel Lookback (h)", minval=2, step=1)
+kernel_r = input.float(4.0, "Kernel Relative Weight (r)", step=0.5)
+kernel_x = input.int(10, "Kernel Regression Level (x)", minval=2, step=1)
+kernel_lag = input.int(1, "Kernel Lag", minval=1, maxval=3)
+jmaPhase = input.int(40, "JMA Phase", minval=-100, maxval=100, step=1)
+jmaPower = input.int(2, "JMA Power", minval=1, maxval=5)
+cvdLength = input.int(14, "CVD Length", minval=1, step=1)
+cvdThreshold = input.float(10.0, "CVD Threshold", step=5.0)
+tradeSession = input.session("0800-0900", "Global Trading Window")
+sessionTimezone = input.string("America/New_York", "Session Timezone", options=["America/New_York", "Etc/GMT+4", "Exchange"])
+cutOffMinutes = input.int(4, "Cut-Off (Minutes before close)", minval=1, maxval=5)
+
+// ==== Volatility Risk Manager ====
+atrLength = input.int(14, "ATR Length", minval=5)
+lowVolThreshold = input.float(10.0, "Low Volatility Threshold (points)", step=1.0)
+highVolThreshold = input.float(25.0, "High Volatility Threshold (points)", step=1.0)
+lowVolSLMult = input.float(1.2, "Low Vol Stop Multiplier", step=0.1)
+normVolSLMult = input.float(1.8, "Normal Vol Stop Multiplier", step=0.1)
+highVolSLMult = input.float(2.5, "High Vol Stop Multiplier", step=0.1)
+rrRatio = input.float(2.5, "Risk/Reward Ratio (TP = SL * R:R)", step=0.25)
+
+exitOnLossMode = input.int(1, "Exit on BG Loss (1=Yes, 0=No)", minval=0, maxval=1, step=1)
+firstFlipMode = input.int(0, "Exit on First Candle Flip (1=Yes, 0=No)", minval=0, maxval=1, step=1)
+sessionTz = sessionTimezone == "Exchange" ? syminfo.timezone : sessionTimezone
+isOneMinute = timeframe.isminutes and timeframe.multiplier == 1
+inWindowRaw = not na(time(timeframe.period, tradeSession, sessionTz))
+inWindow = isOneMinute and inWindowRaw
+subWindowTime = time("15", "", sessionTz)
+isNew15mBar = na(subWindowTime[1]) or subWindowTime != subWindowTime[1]
+windowStart = inWindow and isNew15mBar
+var bool tradedThisSubWindow = false
+if barstate.isnew and windowStart
+    tradedThisSubWindow := false
+if barstate.isnew and not inWindow and inWindow[1]
+    tradedThisSubWindow := false
+var int sessionEndHour = 0
+var int sessionEndMinute = 0
+var float minutesToSessionEnd = na
+var bool hasValidSessionEnd = false
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ""
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ""
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidToken = str.length(endTokenClean) >= 4
+endHourRaw = hasValidToken ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidToken ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+if windowStart
+    hasValidSessionEnd := hasValidToken and not na(endHourRaw) and not na(endMinuteRaw)
+    if hasValidSessionEnd
+        sessionEndHour := int(endHourRaw)
+        sessionEndMinute := int(endMinuteRaw)
+if inWindow and hasValidSessionEnd
+    currentTs = barstate.isrealtime ? timenow : time
+    currentMinuteOfDay = hour(currentTs, sessionTz) * 60 + minute(currentTs, sessionTz)
+    sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+    minutesToSessionEnd := sessionEndMinuteOfDay - currentMinuteOfDay
+else
+    minutesToSessionEnd := na
+withinCutoff = inWindow and hasValidSessionEnd and minutesToSessionEnd < cutOffMinutes
+allowNewEntry = inWindow and not withinCutoff and not tradedThisSubWindow
+trigger1Tf = "120"
+trigger2Tf = "60"
+trigger3Tf = "15"
+triggerTimezone = "Etc/GMT+4"
+trigger4AtrAvgLen = 15
+trigger4AtrMax = 8.0
+jmaLength = 20
+t1 = time(trigger1Tf, "", triggerTimezone)
+t2 = time(trigger2Tf, "", triggerTimezone)
+t3 = time(trigger3Tf, "", triggerTimezone)
+var float trigger1Level = na
+var float trigger2Level = na
+var float trigger3Level = na
+trigger1Level := na(t1[1]) or t1 != t1[1] ? open : nz(trigger1Level[1], open)
+trigger2Level := na(t2[1]) or t2 != t2[1] ? open : nz(trigger2Level[1], open)
+trigger3Level := na(t3[1]) or t3 != t3[1] ? open : nz(trigger3Level[1], open)
+priceAboveAllTriggers = close > trigger1Level and close > trigger2Level and close > trigger3Level
+priceBelowAllTriggers = close < trigger1Level and close < trigger2Level and close < trigger3Level
+trigger1LongBias = close > trigger1Level
+trigger1ShortBias = close < trigger1Level
+trigger4AtrAvg = ta.atr(trigger4AtrAvgLen)
+trigger4VolatilityOk = trigger4AtrAvg <= trigger4AtrMax
+source = close
+yhat1 = kernels.rationalQuadratic(source, kernel_h, kernel_r, kernel_x)
+kernelSmoothLookback = math.max(1, kernel_h - kernel_lag)
+yhat2 = kernels.gaussian(source, kernelSmoothLookback, kernel_x)
+kernelBullish = yhat2 >= yhat1
+kernelBearish = yhat2 <= yhat1
+phaseRatio = jmaPhase < -100 ? 0.5 : jmaPhase > 100 ? 2.5 : jmaPhase / 100 + 1.5
+beta = 0.45 * (jmaLength - 1) / (0.45 * (jmaLength - 1) + 2)
+alpha = math.pow(beta, jmaPower)
+var float jma = na
+var float e0 = na
+var float e1 = na
+var float e2 = na
+e0 := (1 - alpha) * source + alpha * nz(e0[1])
+e1 := (source - e0) * (1 - beta) + beta * nz(e1[1])
+e2 := (e0 + phaseRatio * e1 - nz(jma[1])) * math.pow(1 - alpha, 2) + math.pow(alpha, 2) * nz(e2[1])
+jma := e2 + nz(jma[1])
+jmaLong = jma > jma[1] and close > jma
+jmaShort = jma < jma[1] and close < jma
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpperWick = upperWick / spread
+percentLowerWick = lowerWick / spread
+percentBodyLength = bodyLength / spread
+buyingVolume = close > open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
+sellingVolume = close < open ? (percentBodyLength + (percentUpperWick + percentLowerWick) / 2) * volume : ((percentUpperWick + percentLowerWick) / 2) * volume
+cumulativeBuyingVolume = ta.ema(buyingVolume, cvdLength)
+cumulativeSellingVolume = ta.ema(sellingVolume, cvdLength)
+cvdDelta = cumulativeBuyingVolume - cumulativeSellingVolume
+cvdBullish = cvdDelta > cvdThreshold
+cvdBearish = cvdDelta < -cvdThreshold
+alignLong = jmaLong and kernelBullish
+alignShort = jmaShort and kernelBearish
+bgLong = alignLong and cvdBullish and priceAboveAllTriggers and trigger1LongBias and trigger4VolatilityOk
+bgShort = alignShort and cvdBearish and priceBelowAllTriggers and trigger1ShortBias and trigger4VolatilityOk
+bgDir = bgLong and not bgShort ? 1 : bgShort and not bgLong ? -1 : 0
+bgDirPrev = nz(bgDir[1], 0)
+flipToLong = inWindow and bgDir == 1 and bgDirPrev != 1
+flipToShort = inWindow and bgDir == -1 and bgDirPrev != -1
+longFlipSignal = flipToLong and not windowStart
+shortFlipSignal = flipToShort and not windowStart
+var int firstCandleDir = 0
+var bool firstFlipSeen = false
+if windowStart
+    firstCandleDir := bgDir
+    firstFlipSeen := false
+firstCandleFlipped = barstate.isconfirmed and inWindow and not windowStart and not firstFlipSeen and firstCandleDir != 0 and bgDir != firstCandleDir
+if firstCandleFlipped
+    firstFlipSeen := true
+if firstFlipMode == 1 and firstCandleFlipped and strategy.position_size != 0
+    strategy.close_all(comment="Funky first flip exit", immediately=true)
+exitOnLossOfBG = exitOnLossMode == 1
+if windowStart and not tradedThisSubWindow and not withinCutoff and strategy.position_size == 0
+    if bgLong and not bgShort
+        strategy.entry("Long", strategy.long, comment="AutoStart Long")
+        tradedThisSubWindow := true
+    else if bgShort and not bgLong
+        strategy.entry("Short", strategy.short, comment="AutoStart Short")
+        tradedThisSubWindow := true
+allowSignalEntry = allowNewEntry and not tradedThisSubWindow and strategy.position_size == 0
+if allowSignalEntry and longFlipSignal
+    strategy.entry("Long", strategy.long, comment="Flip Long")
+    tradedThisSubWindow := true
+if allowSignalEntry and shortFlipSignal
+    strategy.entry("Short", strategy.short, comment="Flip Short")
+    tradedThisSubWindow := true
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size > 0 and not bgLong
+    strategy.close("Long", comment="Long BG Lost")
+if exitOnLossOfBG and barstate.isconfirmed and strategy.position_size < 0 and not bgShort
+    strategy.close("Short", comment="Short BG Lost")
+barsSinceWindowStart = ta.barssince(windowStart)
+isLastWindowBar = inWindow and barsSinceWindowStart == 14
+if isLastWindowBar and strategy.position_size != 0
+    strategy.close_all(comment="Window Close (last bar)", immediately=true)
+
+atrValue = ta.atr(atrLength)
+isLowVol = atrValue < lowVolThreshold
+isHighVol = atrValue >= highVolThreshold
+isNormalVol = not isLowVol and not isHighVol
+slMult = isLowVol ? lowVolSLMult : isHighVol ? highVolSLMult : normVolSLMult
+tpMult = slMult * rrRatio
+
+if strategy.position_size > 0
+    strategy.exit("Long Exit", "Long", stop=strategy.position_avg_price - (atrValue * slMult), limit=strategy.position_avg_price + (atrValue * tpMult))
+if strategy.position_size < 0
+    strategy.exit("Short Exit", "Short", stop=strategy.position_avg_price + (atrValue * slMult), limit=strategy.position_avg_price - (atrValue * tpMult))
+
+bgcolor(bgDir == 1 ? color.new(color.teal, 86) : bgDir == -1 ? color.new(color.red, 86) : na, title="BG Signal")
+plotchar(tradedThisSubWindow, "tradedThisWindow", "", location.top, color=color.new(color.white, 0), size=size.tiny, display=display.data_window)
+plotchar(inWindow, "inWindow", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
+plotchar(withinCutoff, "withinCutoff (bloquea entrada)", "", location.top, color=color.new(color.orange, 0), size=size.tiny, display=display.data_window)
+plot(minutesToSessionEnd, "minutesToSessionEnd", color=color.new(color.white, 0), display=display.data_window)
+plot(atrValue, "atrValue", color=color.new(color.yellow, 0), display=display.data_window)
+plotchar(isLowVol, "isLowVol", "", location.top, color=color.new(color.aqua, 0), size=size.tiny, display=display.data_window)
+plotchar(isNormalVol, "isNormalVol", "", location.top, color=color.new(color.gray, 0), size=size.tiny, display=display.data_window)
+plotchar(isHighVol, "isHighVol", "", location.top, color=color.new(color.purple, 0), size=size.tiny, display=display.data_window)

--- a/SZT_TrendAlign_CVD_ATR_Modular_v6.pine
+++ b/SZT_TrendAlign_CVD_ATR_Modular_v6.pine
@@ -1,0 +1,199 @@
+//@version=6
+strategy(
+    "SZT Trend Align + CVD ATR Risk Manager (Modular)",
+    shorttitle="SZT-ATR-Mod",
+    overlay=true,
+    pyramiding=0,
+    default_qty_type=strategy.percent_of_equity,
+    default_qty_value=100,
+    calc_on_every_tick=true,
+    process_orders_on_close=false
+)
+
+// ---------------------------------------------------------------------------
+// Signal Core: SZT Trend align + CVD
+// Keep this block aligned with your indicator so bgLong/bgShort stay identical.
+// ---------------------------------------------------------------------------
+lengthT3 = input.int(4, "T3 Length", minval=1, group="Signal Core - Trend Align + CVD")
+factorT3 = input.float(0.7, "T3 Factor", minval=0.0, maxval=1.0, step=0.05, group="Signal Core - Trend Align + CVD")
+cumulationLength = input.int(16, "CVD Cumulation Length", minval=1, group="Signal Core - Trend Align + CVD")
+baseCvdThreshold = input.float(0.0, "Base CVD Threshold", minval=0.0, step=0.1, group="Signal Core - Trend Align + CVD")
+
+gdT3(src, len, factor) =>
+    ta.ema(src, len) * (1 + factor) - ta.ema(ta.ema(src, len), len) * factor
+
+t3 = gdT3(gdT3(gdT3(close, lengthT3, factorT3), lengthT3, factorT3), lengthT3, factorT3)
+t3Direction = t3 > t3[1] ? 1 : t3 < t3[1] ? -1 : 0
+basicLongT3 = t3Direction > 0 and close > t3
+basicShortT3 = t3Direction < 0 and close < t3
+
+upperWick = close > open ? high - close : high - open
+lowerWick = close > open ? open - low : close - low
+spread = math.max(high - low, syminfo.mintick)
+bodyLength = spread - (upperWick + lowerWick)
+percentUpper = upperWick / spread
+percentLower = lowerWick / spread
+percentBody = bodyLength / spread
+halfWicks = (percentUpper + percentLower) / 2
+buyingVolume = close > open ? (percentBody + halfWicks) * volume : halfWicks * volume
+sellingVolume = close < open ? (percentBody + halfWicks) * volume : halfWicks * volume
+cumBuy = ta.ema(buyingVolume, cumulationLength)
+cumSell = ta.ema(sellingVolume, cumulationLength)
+cvdDelta = cumBuy - cumSell
+bullCVD = cvdDelta > baseCvdThreshold
+bearCVD = cvdDelta < -baseCvdThreshold
+
+// Main directional states used by entry logic.
+bgLong = basicLongT3 and bullCVD
+bgShort = basicShortT3 and bearCVD
+newBgLong = bgLong and not bgLong[1]
+newBgShort = bgShort and not bgShort[1]
+
+// ---------------------------------------------------------------------------
+// Volatility Risk Manager
+// ---------------------------------------------------------------------------
+atrLength = input.int(14, "ATR Length", minval=5, group="Volatility Risk Manager")
+lowVolThreshold = input.float(10.0, "Low Volatility Threshold (points)", step=1.0, group="Volatility Risk Manager")
+highVolThreshold = input.float(25.0, "High Volatility Threshold (points)", step=1.0, group="Volatility Risk Manager")
+lowVolSLMult = input.float(1.2, "Low Vol Stop Multiplier", step=0.1, group="Volatility Risk Manager")
+normVolSLMult = input.float(1.8, "Normal Vol Stop Multiplier", step=0.1, group="Volatility Risk Manager")
+highVolSLMult = input.float(2.5, "High Vol Stop Multiplier", step=0.1, group="Volatility Risk Manager")
+rrRatio = input.float(2.5, "Risk/Reward Ratio (TP = SL * R:R)", step=0.25, group="Volatility Risk Manager")
+
+atrValue = ta.atr(atrLength)
+isLowVol = atrValue < lowVolThreshold
+isHighVol = atrValue >= highVolThreshold
+isNormalVol = not isLowVol and not isHighVol
+slMultCurrent = isLowVol ? lowVolSLMult : isHighVol ? highVolSLMult : normVolSLMult
+tpMultCurrent = slMultCurrent * rrRatio
+
+// ---------------------------------------------------------------------------
+// Session & Cut-Off
+// ---------------------------------------------------------------------------
+tradeSession = input.session("0900-1200", "Global Trading Window", group="Session & Cut-Off")
+cutOffMinutes = input.int(5, "Cut-Off (Minutes before close)", minval=1, maxval=15, group="Session & Cut-Off")
+
+inWindow = not na(time(timeframe.period, tradeSession))
+windowStarted = inWindow and not inWindow[1]
+windowEnded = not inWindow and inWindow[1]
+
+sessionCore = array.get(str.split(tradeSession, ":"), 0)
+sessionRanges = str.split(sessionCore, ",")
+lastRange = array.size(sessionRanges) > 0 ? array.get(sessionRanges, array.size(sessionRanges) - 1) : ""
+rangeParts = str.split(lastRange, "-")
+endToken = array.size(rangeParts) > 1 ? array.get(rangeParts, 1) : ""
+endTokenClean = str.replace_all(endToken, ":", "")
+hasValidEnd = str.length(endTokenClean) >= 4
+endHourRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 0, 2)) : na
+endMinuteRaw = hasValidEnd ? str.tonumber(str.substring(endTokenClean, 2, 4)) : na
+sessionEndHour = hasValidEnd and not na(endHourRaw) ? int(endHourRaw) : 0
+sessionEndMinute = hasValidEnd and not na(endMinuteRaw) ? int(endMinuteRaw) : 0
+sessionEndMinuteOfDay = sessionEndHour * 60 + sessionEndMinute
+
+barCloseMinuteOfDay = hour(time_close) * 60 + minute(time_close)
+minutesToSessionClose = sessionEndMinuteOfDay - barCloseMinuteOfDay
+inCutOff = inWindow and hasValidEnd and minutesToSessionClose < cutOffMinutes and minutesToSessionClose >= 0
+allowEntriesNow = inWindow and not inCutOff
+
+// ---------------------------------------------------------------------------
+// 15m sub-window control + AutoStart
+// AutoStart: on first 1m bar of each 15m sub-window, if bgLong/bgShort is active,
+// allow the corresponding entry even without a "fresh" color flip.
+// ---------------------------------------------------------------------------
+subWindowTime = time("15")
+newSubWindow = inWindow and (windowStarted or subWindowTime != subWindowTime[1])
+
+var bool tradedThisSubWindow = false
+if not inWindow
+    tradedThisSubWindow := false
+else if newSubWindow
+    tradedThisSubWindow := false
+
+isOneMinuteChart = timeframe.isminutes and timeframe.multiplier == 1
+atrReady = not na(atrValue)
+autoStartLong = newSubWindow and bgLong
+autoStartShort = newSubWindow and bgShort
+
+longSignal = isOneMinuteChart and atrReady and allowEntriesNow and strategy.position_size == 0 and not tradedThisSubWindow and (newBgLong or autoStartLong)
+shortSignal = isOneMinuteChart and atrReady and allowEntriesNow and strategy.position_size == 0 and not tradedThisSubWindow and (newBgShort or autoStartShort)
+
+if longSignal and not shortSignal
+    strategy.entry("Long", strategy.long)
+if shortSignal and not longSignal
+    strategy.entry("Short", strategy.short)
+
+// ---------------------------------------------------------------------------
+// Dynamic ATR-based exits (frozen at entry)
+// ---------------------------------------------------------------------------
+var float activeLongStop = na
+var float activeLongTP = na
+var float activeShortStop = na
+var float activeShortTP = na
+var float entryAtr = na
+var float entrySlMult = na
+var float entryTpMult = na
+
+newLong = strategy.position_size > 0 and strategy.position_size[1] <= 0
+newShort = strategy.position_size < 0 and strategy.position_size[1] >= 0
+newPositionOpened = strategy.position_size != 0 and strategy.position_size[1] == 0
+
+if newPositionOpened
+    tradedThisSubWindow := true
+
+if newLong
+    entryAtr := atrValue
+    entrySlMult := slMultCurrent
+    entryTpMult := slMultCurrent * rrRatio
+    stopDistance = entryAtr * entrySlMult
+    tpDistance = entryAtr * entryTpMult
+    activeLongStop := strategy.position_avg_price - stopDistance
+    activeLongTP := strategy.position_avg_price + tpDistance
+    strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
+
+if newShort
+    entryAtr := atrValue
+    entrySlMult := slMultCurrent
+    entryTpMult := slMultCurrent * rrRatio
+    stopDistance = entryAtr * entrySlMult
+    tpDistance = entryAtr * entryTpMult
+    activeShortStop := strategy.position_avg_price + stopDistance
+    activeShortTP := strategy.position_avg_price - tpDistance
+    strategy.exit("Short Exit", "Short", stop=activeShortStop, limit=activeShortTP)
+
+if strategy.position_size > 0 and not na(activeLongStop) and not na(activeLongTP)
+    strategy.exit("Long Exit", "Long", stop=activeLongStop, limit=activeLongTP)
+if strategy.position_size < 0 and not na(activeShortStop) and not na(activeShortTP)
+    strategy.exit("Short Exit", "Short", stop=activeShortStop, limit=activeShortTP)
+
+if strategy.position_size == 0
+    activeLongStop := na
+    activeLongTP := na
+    activeShortStop := na
+    activeShortTP := na
+    entryAtr := na
+    entrySlMult := na
+    entryTpMult := na
+
+if windowEnded and strategy.position_size != 0
+    strategy.close_all(comment="Session end close")
+
+// ---------------------------------------------------------------------------
+// Debug & visual tools
+// ---------------------------------------------------------------------------
+bgcolor(bgLong ? color.new(color.green, 86) : bgShort ? color.new(color.red, 86) : na, title="bgLong/bgShort")
+plot(t3, "T3", color=t3Direction >= 0 ? color.new(color.green, 0) : color.new(color.red, 0), linewidth=2)
+plot(atrValue, "atrValue", color=color.new(color.orange, 0))
+plot(strategy.position_size > 0 ? activeLongStop : na, "Long SL", color=color.new(color.red, 0))
+plot(strategy.position_size > 0 ? activeLongTP : na, "Long TP", color=color.new(color.green, 0))
+plot(strategy.position_size < 0 ? activeShortStop : na, "Short SL", color=color.new(color.red, 0))
+plot(strategy.position_size < 0 ? activeShortTP : na, "Short TP", color=color.new(color.green, 0))
+
+plotchar(inWindow, title="inWindow", char="W", location=location.top, color=color.new(color.white, 0), size=size.tiny)
+plotchar(inCutOff, title="inCutOff", char="C", location=location.top, color=color.new(color.orange, 0), size=size.tiny)
+plotchar(newSubWindow, title="newSubWindow", char="N", location=location.top, color=color.new(color.aqua, 0), size=size.tiny)
+plotchar(tradedThisSubWindow, title="tradedThisSubWindow", char="T", location=location.top, color=color.new(color.yellow, 0), size=size.tiny)
+plotchar(autoStartLong, title="autoStartLong", char="L", location=location.belowbar, color=color.new(color.green, 0), size=size.tiny)
+plotchar(autoStartShort, title="autoStartShort", char="S", location=location.abovebar, color=color.new(color.red, 0), size=size.tiny)
+plotchar(isLowVol, title="Low Vol", char="1", location=location.bottom, color=color.new(color.blue, 0), size=size.tiny)
+plotchar(isNormalVol, title="Normal Vol", char="2", location=location.bottom, color=color.new(color.gray, 0), size=size.tiny)
+plotchar(isHighVol, title="High Vol", char="3", location=location.bottom, color=color.new(color.purple, 0), size=size.tiny)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a reusable Pine v6 strategy template for futures (`SZT_TrendAlign_CVD_ATR_Modular_v6.pine`)
- add a 4=GO strategy version that preserves the stable entry logic and replaces fixed stops/targets with ATR-based dynamic volatility stops (`SZT_Background_Edge_MGC_1m_Strategy.pine`)

## Included strategies
1. **SZT_TrendAlign_CVD_ATR_Modular_v6.pine**
   - modular Trend Align + CVD core (`bgLong` / `bgShort`)
   - 15m sub-window AutoStart behavior
   - dynamic ATR + R:R exit engine

2. **SZT_Background_Edge_MGC_1m_Strategy.pine (4=GO + ATR risk)**
   - keeps stable 4=GO signal/filter logic intact:
     - `trigger1Level`, `trigger2Level`, `trigger3Level`
     - `priceAboveAllTriggers`, `priceBelowAllTriggers`
     - `kernelBullish`, `kernelBearish`, `jmaLong`, `jmaShort`, `cvdBullish`, `cvdBearish`
     - `bgLong` / `bgShort`
     - 15m AutoStart behavior
     - `exitOnLossOfBG` rules
   - removes fixed `stopPts` / `tpPts`
   - adds **Volatility Risk Manager** inputs:
     - `atrLength`
     - `lowVolThreshold`, `highVolThreshold`
     - `lowVolSLMult`, `normVolSLMult`, `highVolSLMult`
     - `rrRatio`
   - applies dynamic exits:
     - `SL = position_avg_price +/- (atrValue * slMult)`
     - `TP = position_avg_price +/- (atrValue * (slMult * rrRatio))`

## Execution settings
- strategies configured for 1m execution style with:
  - `process_orders_on_close=false`
  - `calc_on_every_tick=true`

## Notes
- intended workflow is to duplicate and tune inputs per market (MGC vs MNQ) while keeping logic identical.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d96721ca-eb89-40b2-90b0-57544442e156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d96721ca-eb89-40b2-90b0-57544442e156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

