### PR TITLE
Add Pine v6 liquidity swing module indicator

### DIFF
--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -11,7 +11,6 @@ var lineWidth = input.int(1, "Line Width", minval=1, maxval=4, group="Liquidity 
 var lineStyle = input.string("Solid", "Line Style", options=["Solid", "Dashed", "Dotted"], group="Liquidity Module")
 var labelSize = input.string("Tiny", "Label Size", options=["Tiny", "Small", "Normal"], group="Liquidity Module")
 var labelOffsetX = input.int(-2, "Label Horizontal Offset (bars)", minval=-10, maxval=10, group="Liquidity Module")
-var labelOffsetY = input.int(0, "Label Vertical Offset (ticks)", minval=-10, maxval=10, group="Liquidity Module")
 
 // Fixed variables (not user inputs)
 var bool inputHighlightIntermediates = true
@@ -77,7 +76,7 @@ if not na(swingHighPrice)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
     swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice + syminfo.mintick * labelOffsetY, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -98,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice + syminfo.mintick * labelOffsetY, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -130,7 +129,7 @@ if barstate.isnew
                 highLevelBar = line.get_x1(highLineId)
                 highAge = bar_index - highLevelBar + 1
                 highLabelX = line.get_x2(highLineId) + labelOffsetX
-                highLabelY = highLevelPrice + syminfo.mintick * labelOffsetY
+                highLabelY = highLevelPrice
                 if na(highLabelId)
                     newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
                     array.set(swingHighLabels, i, newHighLabel)
@@ -153,7 +152,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice + syminfo.mintick * labelOffsetY
+                lowLabelY = lowLevelPrice
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -182,7 +181,7 @@ if barstate.isconfirmed
                         line.set_extend(highLineId, extend.none)
                         if not na(highLabelId)
                             highLabelX = bar_index + labelOffsetX
-                            highLabelY = highLevelPrice + syminfo.mintick * labelOffsetY
+                            highLabelY = highLevelPrice
                             highAge = bar_index - line.get_x1(highLineId) + 1
                             label.set_xy(highLabelId, line.get_x2(highLineId) + labelOffsetX, highLabelY)
                             label.set_text(highLabelId, str.tostring(highAge))
@@ -207,7 +206,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice + syminfo.mintick * labelOffsetY
+                            lowLabelY = lowLevelPrice
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -17,9 +17,6 @@ var bool inputHighlightIntermediates = true
 var bool inputShowShortTermSwings = true
 var string inputIntermediateSize = "Tiny"
 var intermediateLabelSize = size.tiny
-var int labelOffsetY = 0
-var int highLabelOffsetTicks = 2
-var int lowLabelOffsetTicks = -2
 
 lineStyleValue = lineStyle == "Dashed" ? line.style_dashed : lineStyle == "Dotted" ? line.style_dotted : line.style_solid
 selectedLabelSize = labelSize == "Small" ? size.small : labelSize == "Normal" ? size.normal : size.tiny
@@ -79,7 +76,7 @@ if not na(swingHighPrice)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
     swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice + syminfo.mintick * highLabelOffsetTicks, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice + syminfo.mintick * 2, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -100,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice + syminfo.mintick * lowLabelOffsetTicks, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 2, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -132,7 +129,7 @@ if barstate.isnew
                 highLevelBar = line.get_x1(highLineId)
                 highAge = bar_index - highLevelBar + 1
                 highLabelX = line.get_x2(highLineId) + labelOffsetX
-                highLabelY = highLevelPrice + syminfo.mintick * highLabelOffsetTicks
+                highLabelY = highLevelPrice + syminfo.mintick * 2
                 if na(highLabelId)
                     newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
                     array.set(swingHighLabels, i, newHighLabel)
@@ -155,7 +152,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice + syminfo.mintick * lowLabelOffsetTicks
+                lowLabelY = lowLevelPrice - syminfo.mintick * 2
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -184,7 +181,7 @@ if barstate.isconfirmed
                         line.set_extend(highLineId, extend.none)
                         if not na(highLabelId)
                             highLabelX = bar_index + labelOffsetX
-                            highLabelY = highLevelPrice + syminfo.mintick * highLabelOffsetTicks
+                            highLabelY = highLevelPrice + syminfo.mintick * 2
                             highAge = bar_index - line.get_x1(highLineId) + 1
                             label.set_xy(highLabelId, line.get_x2(highLineId) + labelOffsetX, highLabelY)
                             label.set_text(highLabelId, str.tostring(highAge))
@@ -209,7 +206,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice + syminfo.mintick * lowLabelOffsetTicks
+                            lowLabelY = lowLevelPrice - syminfo.mintick * 2
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -27,8 +27,22 @@ var line[] swingLowLines = array.new_line()
 var bool[] swingLowIsLower = array.new_bool()
 var bool[] swingLowIsIntermediate = array.new_bool()
 
-// See last element pushed in an array.
-array_peek(arrayId) =>
+// See last element pushed in typed arrays.
+array_peek_float(float[] arrayId) =>
+    int arraySize = array.size(arrayId)
+    if arraySize > 0
+        array.get(arrayId, arraySize - 1)
+    else
+        na
+
+array_peek_bool(bool[] arrayId) =>
+    int arraySize = array.size(arrayId)
+    if arraySize > 0
+        array.get(arrayId, arraySize - 1)
+    else
+        false
+
+array_peek_line(line[] arrayId) =>
     int arraySize = array.size(arrayId)
     if arraySize > 0
         array.get(arrayId, arraySize - 1)
@@ -55,16 +69,16 @@ swingHighPrice = ta.pivothigh(high, inputPivotBars, inputPivotBars)
 swingLowPrice = ta.pivotlow(low, inputPivotBars, inputPivotBars)
 
 if not na(swingHighPrice)
-    lastSwingHighPrice = array_peek(swingHighs)
+    lastSwingHighPrice = array_peek_float(swingHighs)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
     swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=line.style_solid, width=lineWidth)
 
     // Check if last swing high was intermediate.
-    if isLowerHigh and array_peek(swingHighIsHigher)
+    if isLowerHigh and array_peek_bool(swingHighIsHigher)
         // Lower high after a higher high means the previous swing high was intermediate.
         if inputHighlightIntermediates
-            line.set_width(array_peek(swingHighLines), intermediateLineWidth)
+            line.set_width(array_peek_line(swingHighLines), intermediateLineWidth)
             array.set(swingHighIsIntermediate, array.size(swingHighIsIntermediate) - 1, true)
 
     // Save swing.
@@ -74,16 +88,16 @@ if not na(swingHighPrice)
     array.push(swingHighIsIntermediate, false) // Can be filled in later, if a lower high forms next.
 
 if not na(swingLowPrice)
-    lastSwingLowPrice = array_peek(swingLows)
+    lastSwingLowPrice = array_peek_float(swingLows)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=line.style_solid, width=lineWidth)
 
     // Check if last swing low was intermediate.
-    if isHigherLow and array_peek(swingLowIsLower)
+    if isHigherLow and array_peek_bool(swingLowIsLower)
         // Higher low after a lower low means the previous swing low was intermediate.
         if inputHighlightIntermediates
-            line.set_width(array_peek(swingLowLines), intermediateLineWidth)
+            line.set_width(array_peek_line(swingLowLines), intermediateLineWidth)
             array.set(swingLowIsIntermediate, array.size(swingLowIsIntermediate) - 1, true)
 
     // Save swing.

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -1,19 +1,18 @@
 // This source code is subject to the terms of the Mozilla Public License 2.0 at https://mozilla.org/MPL/2.0/
 
 //@version=5
-indicator("M1 Liquidez (Swings)", overlay=true, max_labels_count=500)
+indicator("M1 Liquidez (Swings)", shorttitle="M1 Liquidity", overlay=true, max_labels_count=500)
 
+// === Liquidity Module Settings ===
+var inputPivotBars = input(5, "Pivot Candles", group="Liquidity Module")
+var highcolor = input.color(color.red, "High Color", group="Liquidity Module")
+var lowcolor = input.color(color.green, "Low Color", group="Liquidity Module")
+
+// Fixed variables (not user inputs)
 var bool inputHighlightIntermediates = true
-var string inputIntermediateSize = "Tiny"
 var bool inputShowShortTermSwings = true
-var inputPivotBars = input(5, "Pivot Candles")
-var highcolor = input.color(color.red, title="High", tooltip="select a color for ST/IT Highs")
-var lowcolor = input.color(color.green, title="Low", tooltip="select a color for ST/IT Lows")
-var circleSize = input.string("Tiny", "Tamaño de los círculos", options=["Tiny", "Small", "Normal"])
-var circleOffsetTicks = input.int(0, "Desplazamiento vertical de círculos (ticks)", minval=-10, maxval=10)
-
-var intermediateLabelSize = inputIntermediateSize == "Auto" ? size.auto : inputIntermediateSize == "Tiny" ? size.tiny : inputIntermediateSize == "Small" ? size.small : size.normal
-var selectedCircleSize = circleSize == "Small" ? size.small : circleSize == "Normal" ? size.normal : size.tiny
+var string inputIntermediateSize = "Tiny"
+var intermediateLabelSize = size.tiny
 
 // Parallel arrays for Swing High Data
 var float[] swingHighs = array.new_float()
@@ -59,7 +58,7 @@ if not na(swingHighPrice)
     lastSwingHighPrice = array_peek(swingHighs)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
-    swingLabel = label.new(bar_index[inputPivotBars], swingHighPrice + syminfo.mintick * circleOffsetTicks, color=highcolor, yloc=yloc.price, style=label.style_circle, size=selectedCircleSize)
+    swingLabel = label.new(bar_index[inputPivotBars], swingHighPrice, color=highcolor, yloc=yloc.price, style=label.style_circle, size=size.tiny)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -78,7 +77,7 @@ if not na(swingLowPrice)
     lastSwingLowPrice = array_peek(swingLows)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
-    swingLabel = label.new(bar_index[inputPivotBars], swingLowPrice + syminfo.mintick * circleOffsetTicks, color=lowcolor, yloc=yloc.price, style=label.style_circle, size=selectedCircleSize)
+    swingLabel = label.new(bar_index[inputPivotBars], swingLowPrice, color=lowcolor, yloc=yloc.price, style=label.style_circle, size=size.tiny)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -1,12 +1,13 @@
 // This source code is subject to the terms of the Mozilla Public License 2.0 at https://mozilla.org/MPL/2.0/
 
 //@version=5
-indicator("M1 Liquidez (Swings)", shorttitle="M1 Liquidity", overlay=true, max_labels_count=500)
+indicator("M1 Liquidez (Swings)", shorttitle="M1 Liquidity", overlay=true, max_lines_count=500)
 
 // === Liquidity Module Settings ===
 var inputPivotBars = input(5, "Pivot Candles", group="Liquidity Module")
-var highcolor = input.color(color.red, "High Color", group="Liquidity Module")
-var lowcolor = input.color(color.green, "Low Color", group="Liquidity Module")
+var highcolor = input.color(color.rgb(70, 184, 42), "High Color", group="Liquidity Module")
+var lowcolor = input.color(color.rgb(200, 200, 200), "Low Color", group="Liquidity Module")
+var lineWidth = input.int(1, "Line Width", minval=1, maxval=4, group="Liquidity Module")
 
 // Fixed variables (not user inputs)
 var bool inputHighlightIntermediates = true
@@ -16,13 +17,13 @@ var intermediateLabelSize = size.tiny
 
 // Parallel arrays for Swing High Data
 var float[] swingHighs = array.new_float()
-var label[] swingHighLabels = array.new_label()
+var line[] swingHighLines = array.new_line()
 var bool[] swingHighIsHigher = array.new_bool()
 var bool[] swingHighIsIntermediate = array.new_bool()
 
 // Parallel arrays for Swing Low Data
 var float[] swingLows = array.new_float()
-var label[] swingLowLabels = array.new_label()
+var line[] swingLowLines = array.new_line()
 var bool[] swingLowIsLower = array.new_bool()
 var bool[] swingLowIsIntermediate = array.new_bool()
 
@@ -37,16 +38,16 @@ array_peek(arrayId) =>
 // filters out swings that were not intermediate swings after all swings have been recorded.
 remove_short_term_swings() =>
     if not inputShowShortTermSwings and barstate.islast
-        var swingHighCount = array.size(swingHighLabels)
-        var swingLowCount = array.size(swingLowLabels)
+        var swingHighCount = array.size(swingHighLines)
+        var swingLowCount = array.size(swingLowLines)
 
         for i = 0 to swingHighCount - 1 by 1
             if not array.get(swingHighIsIntermediate, i)
-                label.delete(array.get(swingHighLabels, i))
+                line.delete(array.get(swingHighLines, i))
 
         for i = 0 to swingLowCount - 1 by 1
             if not array.get(swingLowIsIntermediate, i)
-                label.delete(array.get(swingLowLabels, i))
+                line.delete(array.get(swingLowLines, i))
 
 
 // detect swing highs and lows
@@ -58,18 +59,19 @@ if not na(swingHighPrice)
     lastSwingHighPrice = array_peek(swingHighs)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
-    swingLabel = label.new(bar_index[inputPivotBars], swingHighPrice, color=highcolor, yloc=yloc.price, style=label.style_circle, size=size.tiny)
+    swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=line.style_solid, width=lineWidth)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
         // lower high after a higher high means the previous swing high was intermediate
         if inputHighlightIntermediates
-            label.set_size(array_peek(swingHighLabels), intermediateLabelSize)
+            previousSwingHighLine = array.get(swingHighLines, array.size(swingHighLines) - 1)
+            line.set_width(previousSwingHighLine, lineWidth + 1)
             array.set(swingHighIsIntermediate, array.size(swingHighIsIntermediate) - 1, true)
 
     // save swing
     array.push(swingHighs, swingHighPrice)
-    array.push(swingHighLabels, swingLabel)
+    array.push(swingHighLines, swingLine)
     array.push(swingHighIsHigher, isHigherHigh)
     array.push(swingHighIsIntermediate, false) // can be filled in later, if a lower high forms next
 
@@ -77,18 +79,19 @@ if not na(swingLowPrice)
     lastSwingLowPrice = array_peek(swingLows)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
-    swingLabel = label.new(bar_index[inputPivotBars], swingLowPrice, color=lowcolor, yloc=yloc.price, style=label.style_circle, size=size.tiny)
+    swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=line.style_solid, width=lineWidth)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
         // higher low after a lower low means the previous swing low was intermediate
         if inputHighlightIntermediates
-            label.set_size(array_peek(swingLowLabels), intermediateLabelSize)
+            previousSwingLowLine = array.get(swingLowLines, array.size(swingLowLines) - 1)
+            line.set_width(previousSwingLowLine, lineWidth + 1)
             array.set(swingLowIsIntermediate, array.size(swingLowIsIntermediate) - 1, true)
 
     // save swing
     array.push(swingLows, swingLowPrice)
-    array.push(swingLowLabels, swingLabel)
+    array.push(swingLowLines, swingLine)
     array.push(swingLowIsLower, isLowerLow)
     array.push(swingLowIsIntermediate, false) // can be filled in later if a higher low forms next
 

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -76,7 +76,7 @@ if not na(swingHighPrice)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
     swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -131,14 +131,14 @@ if barstate.isnew
                 highLabelX = line.get_x2(highLineId) + labelOffsetX
                 highLabelY = highLevelPrice
                 if na(highLabelId)
-                    newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
+                    newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
                     array.set(swingHighLabels, i, newHighLabel)
                 else
                     label.set_xy(highLabelId, highLabelX, highLabelY)
                     label.set_text(highLabelId, str.tostring(highAge))
                     label.set_textcolor(highLabelId, highcolor)
                     label.set_size(highLabelId, selectedLabelSize)
-                    label.set_style(highLabelId, label.style_none)
+                    label.set_style(highLabelId, label.style_label_down)
                     label.set_color(highLabelId, color.new(color.white, 100))
 
     int swingLowLabelCount = array.size(swingLowLines)
@@ -154,14 +154,14 @@ if barstate.isnew
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
                 lowLabelY = lowLevelPrice
                 if na(lowLabelId)
-                    newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+                    newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
                 else
                     label.set_xy(lowLabelId, lowLabelX, lowLabelY)
                     label.set_text(lowLabelId, str.tostring(lowAge))
                     label.set_textcolor(lowLabelId, lowcolor)
                     label.set_size(lowLabelId, selectedLabelSize)
-                    label.set_style(lowLabelId, label.style_none)
+                    label.set_style(lowLabelId, label.style_label_up)
                     label.set_color(lowLabelId, color.new(color.white, 100))
 
 // Sweep management: cut line when price touches/exceeds the liquidity level.
@@ -187,7 +187,7 @@ if barstate.isconfirmed
                             label.set_text(highLabelId, str.tostring(highAge))
                             label.set_textcolor(highLabelId, highcolor)
                             label.set_size(highLabelId, selectedLabelSize)
-                            label.set_style(highLabelId, label.style_none)
+                            label.set_style(highLabelId, label.style_label_down)
                             label.set_color(highLabelId, color.new(color.white, 100))
                         array.set(swingHighSwept, i, true)
 
@@ -212,6 +212,6 @@ if barstate.isconfirmed
                             label.set_text(lowLabelId, str.tostring(lowAge))
                             label.set_textcolor(lowLabelId, lowcolor)
                             label.set_size(lowLabelId, selectedLabelSize)
-                            label.set_style(lowLabelId, label.style_none)
+                            label.set_style(lowLabelId, label.style_label_up)
                             label.set_color(lowLabelId, color.new(color.white, 100))
                         array.set(swingLowSwept, i, true)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -8,9 +8,8 @@ groupSwings = "Swings"
 groupLines = "Lineas de Liquidez"
 groupLabels = "Etiquetas de Maduracion"
 
-pivotBars = input.int(5, "Pivot Length", minval=1, group=groupSwings)
+pivotBars = input.int(3, "Pivot Length", minval=1, group=groupSwings)
 maxVisibleSwings = input.int(100, "Max Sweeps Visibles", minval=10, maxval=500, group=groupSwings)
-showShortTermSwings = input.bool(false, "Mostrar swings cortos", group=groupSwings)
 
 colorHigh = input.color(color.red, "Color Swing High", group=groupLines)
 colorLow = input.color(color.green, "Color Swing Low", group=groupLines)
@@ -51,19 +50,6 @@ var float[] swingLowPrices = array.new_float()
 var int[] swingLowBars = array.new_int()
 var bool[] swingLowIsActive = array.new_bool()
 
-// -----------------------------------------------------------------------------
-// Store all pivot swings for intermediate confirmation logic
-// -----------------------------------------------------------------------------
-var float[] allSwingHighs = array.new_float()
-var int[] allSwingHighBars = array.new_int()
-var bool[] allSwingHighIsHigher = array.new_bool()
-var bool[] allSwingHighIsIntermediate = array.new_bool()
-
-var float[] allSwingLows = array.new_float()
-var int[] allSwingLowBars = array.new_int()
-var bool[] allSwingLowIsLower = array.new_bool()
-var bool[] allSwingLowIsIntermediate = array.new_bool()
-
 trimHighVisibility(maxItems) =>
     while array.size(swingHighLines) > maxItems
         oldLine = array.pop(swingHighLines)
@@ -95,69 +81,23 @@ selectedLineStyle = lineStyleFromInput(lineStyleInput)
 
 if not na(swingHighPrice)
     swingBarIndex = bar_index - pivotBars
-    lastHighPrice = array.size(allSwingHighs) > 0 ? array.get(allSwingHighs, array.size(allSwingHighs) - 1) : na
-    isHigherHigh = not na(lastHighPrice) and swingHighPrice > lastHighPrice
-    isLowerHigh = not na(lastHighPrice) and swingHighPrice < lastHighPrice
-
-    array.push(allSwingHighs, swingHighPrice)
-    array.push(allSwingHighBars, swingBarIndex)
-    array.push(allSwingHighIsHigher, isHigherHigh)
-    array.push(allSwingHighIsIntermediate, false)
-
-    drawLineNow = showShortTermSwings
-    drawPrice = swingHighPrice
-    drawBar = swingBarIndex
-
-    if isLowerHigh and array.size(allSwingHighs) > 1
-        prevHighIndex = array.size(allSwingHighs) - 2
-        if array.get(allSwingHighIsHigher, prevHighIndex)
-            array.set(allSwingHighIsIntermediate, prevHighIndex, true)
-            if not showShortTermSwings
-                drawLineNow := true
-                drawPrice := array.get(allSwingHighs, prevHighIndex)
-                drawBar := array.get(allSwingHighBars, prevHighIndex)
-
-    if drawLineNow
-        highLine = line.new(drawBar, drawPrice, bar_index, drawPrice, xloc=xloc.bar_index, extend=extend.right, color=colorHigh, style=selectedLineStyle, width=lineWidth)
-        array.unshift(swingHighLines, highLine)
-        array.unshift(swingHighLabels, na)
-        array.unshift(swingHighPrices, drawPrice)
-        array.unshift(swingHighBars, drawBar)
-        array.unshift(swingHighIsActive, true)
-        trimHighVisibility(maxVisibleSwings)
+    highLine = line.new(swingBarIndex, swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=colorHigh, style=selectedLineStyle, width=lineWidth)
+    array.unshift(swingHighLines, highLine)
+    array.unshift(swingHighLabels, na)
+    array.unshift(swingHighPrices, swingHighPrice)
+    array.unshift(swingHighBars, swingBarIndex)
+    array.unshift(swingHighIsActive, true)
+    trimHighVisibility(maxVisibleSwings)
 
 if not na(swingLowPrice)
     swingBarIndex = bar_index - pivotBars
-    lastLowPrice = array.size(allSwingLows) > 0 ? array.get(allSwingLows, array.size(allSwingLows) - 1) : na
-    isHigherLow = not na(lastLowPrice) and swingLowPrice > lastLowPrice
-    isLowerLow = not na(lastLowPrice) and swingLowPrice < lastLowPrice
-
-    array.push(allSwingLows, swingLowPrice)
-    array.push(allSwingLowBars, swingBarIndex)
-    array.push(allSwingLowIsLower, isLowerLow)
-    array.push(allSwingLowIsIntermediate, false)
-
-    drawLineNow = showShortTermSwings
-    drawPrice = swingLowPrice
-    drawBar = swingBarIndex
-
-    if isHigherLow and array.size(allSwingLows) > 1
-        prevLowIndex = array.size(allSwingLows) - 2
-        if array.get(allSwingLowIsLower, prevLowIndex)
-            array.set(allSwingLowIsIntermediate, prevLowIndex, true)
-            if not showShortTermSwings
-                drawLineNow := true
-                drawPrice := array.get(allSwingLows, prevLowIndex)
-                drawBar := array.get(allSwingLowBars, prevLowIndex)
-
-    if drawLineNow
-        lowLine = line.new(drawBar, drawPrice, bar_index, drawPrice, xloc=xloc.bar_index, extend=extend.right, color=colorLow, style=selectedLineStyle, width=lineWidth)
-        array.unshift(swingLowLines, lowLine)
-        array.unshift(swingLowLabels, na)
-        array.unshift(swingLowPrices, drawPrice)
-        array.unshift(swingLowBars, drawBar)
-        array.unshift(swingLowIsActive, true)
-        trimLowVisibility(maxVisibleSwings)
+    lowLine = line.new(swingBarIndex, swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=colorLow, style=selectedLineStyle, width=lineWidth)
+    array.unshift(swingLowLines, lowLine)
+    array.unshift(swingLowLabels, na)
+    array.unshift(swingLowPrices, swingLowPrice)
+    array.unshift(swingLowBars, swingBarIndex)
+    array.unshift(swingLowIsActive, true)
+    trimLowVisibility(maxVisibleSwings)
 
 // -----------------------------------------------------------------------------
 // Manage high sweeps

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -9,6 +9,7 @@ var highcolor = input.color(color.rgb(70, 184, 42), "High Color", group="Liquidi
 var lowcolor = input.color(color.rgb(200, 200, 200), "Low Color", group="Liquidity Module")
 var lineWidth = input.int(1, "Line Width", minval=1, maxval=4, group="Liquidity Module")
 var lineStyle = input.string("Solid", "Line Style", options=["Solid", "Dashed", "Dotted"], group="Liquidity Module")
+var deleteOnSweep = input.bool(false, "Delete line after sweep", group="Liquidity Module")
 
 // Fixed variables (not user inputs)
 var bool inputHighlightIntermediates = true
@@ -23,12 +24,14 @@ var float[] swingHighs = array.new_float()
 var line[] swingHighLines = array.new_line()
 var bool[] swingHighIsHigher = array.new_bool()
 var bool[] swingHighIsIntermediate = array.new_bool()
+var bool[] swingHighSwept = array.new_bool()
 
 // Parallel arrays for Swing Low Data
 var float[] swingLows = array.new_float()
 var line[] swingLowLines = array.new_line()
 var bool[] swingLowIsLower = array.new_bool()
 var bool[] swingLowIsIntermediate = array.new_bool()
+var bool[] swingLowSwept = array.new_bool()
 
 // see last element pushed an an array
 array_peek(arrayId) =>
@@ -75,6 +78,7 @@ if not na(swingHighPrice)
     array.push(swingHighLines, swingLine)
     array.push(swingHighIsHigher, isHigherHigh)
     array.push(swingHighIsIntermediate, false) // can be filled in later, if a lower high forms next
+    array.push(swingHighSwept, false)
 
 if not na(swingLowPrice)
     lastSwingLowPrice = array_peek(swingLows)
@@ -93,6 +97,45 @@ if not na(swingLowPrice)
     array.push(swingLowLines, swingLine)
     array.push(swingLowIsLower, isLowerLow)
     array.push(swingLowIsIntermediate, false) // can be filled in later if a higher low forms next
+    array.push(swingLowSwept, false)
 
 
 remove_short_term_swings()
+
+// Sweep management: cut line when price touches/exceeds the liquidity level.
+if barstate.isconfirmed
+    int swingHighCount = array.size(swingHighLines)
+    if swingHighCount > 0
+        for i = 0 to swingHighCount - 1 by 1
+            line highLineId = array.get(swingHighLines, i)
+            bool highWasSwept = array.get(swingHighSwept, i)
+            if not highWasSwept and not na(highLineId)
+                // Skip lines that were created on this same bar.
+                if line.get_x2(highLineId) < bar_index
+                    highLevelPrice = line.get_y1(highLineId)
+                    if high >= highLevelPrice
+                        if deleteOnSweep
+                            line.delete(highLineId)
+                            array.set(swingHighLines, i, na)
+                        else
+                            line.set_x2(highLineId, bar_index)
+                            line.set_extend(highLineId, extend.none)
+                        array.set(swingHighSwept, i, true)
+
+    int swingLowCount = array.size(swingLowLines)
+    if swingLowCount > 0
+        for i = 0 to swingLowCount - 1 by 1
+            line lowLineId = array.get(swingLowLines, i)
+            bool lowWasSwept = array.get(swingLowSwept, i)
+            if not lowWasSwept and not na(lowLineId)
+                // Skip lines that were created on this same bar.
+                if line.get_x2(lowLineId) < bar_index
+                    lowLevelPrice = line.get_y1(lowLineId)
+                    if low <= lowLevelPrice
+                        if deleteOnSweep
+                            line.delete(lowLineId)
+                            array.set(swingLowLines, i, na)
+                        else
+                            line.set_x2(lowLineId, bar_index)
+                            line.set_extend(lowLineId, extend.none)
+                        array.set(swingLowSwept, i, true)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -5,8 +5,8 @@ indicator("M1 Liquidez (Swings)", shorttitle="M1 Liquidity", overlay=true, max_l
 
 // === Liquidity Module Settings ===
 var inputPivotBars = input(5, "Pivot Candles", group="Liquidity Module")
-var highcolor = input.color(color.rgb(70, 184, 42), "High Color", group="Liquidity Module")
-var lowcolor = input.color(color.rgb(200, 200, 200), "Low Color", group="Liquidity Module")
+var highcolor = input.color(color.rgb(70, 184, 42), "Swing High Color", group="Liquidity Module")
+var lowcolor = input.color(color.rgb(200, 200, 200), "Swing Low Color", group="Liquidity Module")
 var lineWidth = input.int(1, "Line Width", minval=1, maxval=4, group="Liquidity Module")
 var lineStyle = input.string("Solid", "Line Style", options=["Solid", "Dashed", "Dotted"], group="Liquidity Module")
 var deleteOnSweep = input.bool(false, "Delete line after sweep", group="Liquidity Module")

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -3,14 +3,17 @@
 //@version=5
 indicator("M1 Liquidez (Swings)", overlay=true, max_labels_count=500)
 
-var inputHighlightIntermediates = input(true, "Highlight Intermediate Swing Highs and Lows")
-var inputIntermediateSize = input.string("Tiny", "Intermediate Swing Label Size", options=["Auto", "Tiny", "Small", "Normal"])
-var inputShowShortTermSwings = input(false, "Short Term Swings")
-var inputPivotBars = input(2, "Pivot Candles")
+var bool inputHighlightIntermediates = true
+var string inputIntermediateSize = "Tiny"
+var bool inputShowShortTermSwings = true
+var inputPivotBars = input(5, "Pivot Candles")
 var highcolor = input.color(color.red, title="High", tooltip="select a color for ST/IT Highs")
 var lowcolor = input.color(color.green, title="Low", tooltip="select a color for ST/IT Lows")
+var circleSize = input.string("Tiny", "Tamaño de los círculos", options=["Tiny", "Small", "Normal"])
+var circleOffsetTicks = input.int(0, "Desplazamiento vertical de círculos (ticks)", minval=-10, maxval=10)
 
 var intermediateLabelSize = inputIntermediateSize == "Auto" ? size.auto : inputIntermediateSize == "Tiny" ? size.tiny : inputIntermediateSize == "Small" ? size.small : size.normal
+var selectedCircleSize = circleSize == "Small" ? size.small : circleSize == "Normal" ? size.normal : size.tiny
 
 // Parallel arrays for Swing High Data
 var float[] swingHighs = array.new_float()
@@ -56,7 +59,7 @@ if not na(swingHighPrice)
     lastSwingHighPrice = array_peek(swingHighs)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
-    swingLabel = label.new(bar_index[inputPivotBars], swingHighPrice, color=highcolor, yloc=yloc.price, style=label.style_circle, size=size.tiny)
+    swingLabel = label.new(bar_index[inputPivotBars], swingHighPrice + syminfo.mintick * circleOffsetTicks, color=highcolor, yloc=yloc.price, style=label.style_circle, size=selectedCircleSize)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -75,7 +78,7 @@ if not na(swingLowPrice)
     lastSwingLowPrice = array_peek(swingLows)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
-    swingLabel = label.new(bar_index[inputPivotBars], swingLowPrice, color=lowcolor, yloc=yloc.price, style=label.style_circle, size=size.tiny)
+    swingLabel = label.new(bar_index[inputPivotBars], swingLowPrice + syminfo.mintick * circleOffsetTicks, color=lowcolor, yloc=yloc.price, style=label.style_circle, size=selectedCircleSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -128,7 +128,7 @@ if barstate.isnew
             label highLabelId = array.get(swingHighLabels, i)
             bool highWasSwept = array.get(swingHighSwept, i)
             if not na(highLineId) and not highWasSwept
-                line.set_x2(highLineId, bar_index)
+                line.set_x2(highLineId, bar_index + 10)
                 line.set_extend(highLineId, extend.none)
                 highLevelPrice = line.get_y1(highLineId)
                 highLevelBar = line.get_x1(highLineId)
@@ -153,7 +153,7 @@ if barstate.isnew
             label lowLabelId = array.get(swingLowLabels, i)
             bool lowWasSwept = array.get(swingLowSwept, i)
             if not na(lowLineId) and not lowWasSwept
-                line.set_x2(lowLineId, bar_index)
+                line.set_x2(lowLineId, bar_index + 10)
                 line.set_extend(lowLineId, extend.none)
                 lowLevelPrice = line.get_y1(lowLineId)
                 lowLevelBar = line.get_x1(lowLineId)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -10,6 +10,7 @@ groupLabels = "Etiquetas de Maduracion"
 
 pivotBars = input.int(5, "Pivot Length", minval=1, group=groupSwings)
 maxVisibleSwings = input.int(100, "Max Sweeps Visibles", minval=10, maxval=500, group=groupSwings)
+showShortTermSwings = input.bool(false, "Mostrar swings cortos", group=groupSwings)
 
 colorHigh = input.color(color.red, "Color Swing High", group=groupLines)
 colorLow = input.color(color.green, "Color Swing Low", group=groupLines)
@@ -50,6 +51,19 @@ var float[] swingLowPrices = array.new_float()
 var int[] swingLowBars = array.new_int()
 var bool[] swingLowIsActive = array.new_bool()
 
+// -----------------------------------------------------------------------------
+// Store all pivot swings for intermediate confirmation logic
+// -----------------------------------------------------------------------------
+var float[] allSwingHighs = array.new_float()
+var int[] allSwingHighBars = array.new_int()
+var bool[] allSwingHighIsHigher = array.new_bool()
+var bool[] allSwingHighIsIntermediate = array.new_bool()
+
+var float[] allSwingLows = array.new_float()
+var int[] allSwingLowBars = array.new_int()
+var bool[] allSwingLowIsLower = array.new_bool()
+var bool[] allSwingLowIsIntermediate = array.new_bool()
+
 trimHighVisibility(maxItems) =>
     while array.size(swingHighLines) > maxItems
         oldLine = array.pop(swingHighLines)
@@ -81,23 +95,69 @@ selectedLineStyle = lineStyleFromInput(lineStyleInput)
 
 if not na(swingHighPrice)
     swingBarIndex = bar_index - pivotBars
-    highLine = line.new(swingBarIndex, swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=colorHigh, style=selectedLineStyle, width=lineWidth)
-    array.unshift(swingHighLines, highLine)
-    array.unshift(swingHighLabels, na)
-    array.unshift(swingHighPrices, swingHighPrice)
-    array.unshift(swingHighBars, swingBarIndex)
-    array.unshift(swingHighIsActive, true)
-    trimHighVisibility(maxVisibleSwings)
+    lastHighPrice = array.size(allSwingHighs) > 0 ? array.get(allSwingHighs, array.size(allSwingHighs) - 1) : na
+    isHigherHigh = not na(lastHighPrice) and swingHighPrice > lastHighPrice
+    isLowerHigh = not na(lastHighPrice) and swingHighPrice < lastHighPrice
+
+    array.push(allSwingHighs, swingHighPrice)
+    array.push(allSwingHighBars, swingBarIndex)
+    array.push(allSwingHighIsHigher, isHigherHigh)
+    array.push(allSwingHighIsIntermediate, false)
+
+    drawLineNow = showShortTermSwings
+    drawPrice = swingHighPrice
+    drawBar = swingBarIndex
+
+    if isLowerHigh and array.size(allSwingHighs) > 1
+        prevHighIndex = array.size(allSwingHighs) - 2
+        if array.get(allSwingHighIsHigher, prevHighIndex)
+            array.set(allSwingHighIsIntermediate, prevHighIndex, true)
+            if not showShortTermSwings
+                drawLineNow := true
+                drawPrice := array.get(allSwingHighs, prevHighIndex)
+                drawBar := array.get(allSwingHighBars, prevHighIndex)
+
+    if drawLineNow
+        highLine = line.new(drawBar, drawPrice, bar_index, drawPrice, xloc=xloc.bar_index, extend=extend.right, color=colorHigh, style=selectedLineStyle, width=lineWidth)
+        array.unshift(swingHighLines, highLine)
+        array.unshift(swingHighLabels, na)
+        array.unshift(swingHighPrices, drawPrice)
+        array.unshift(swingHighBars, drawBar)
+        array.unshift(swingHighIsActive, true)
+        trimHighVisibility(maxVisibleSwings)
 
 if not na(swingLowPrice)
     swingBarIndex = bar_index - pivotBars
-    lowLine = line.new(swingBarIndex, swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=colorLow, style=selectedLineStyle, width=lineWidth)
-    array.unshift(swingLowLines, lowLine)
-    array.unshift(swingLowLabels, na)
-    array.unshift(swingLowPrices, swingLowPrice)
-    array.unshift(swingLowBars, swingBarIndex)
-    array.unshift(swingLowIsActive, true)
-    trimLowVisibility(maxVisibleSwings)
+    lastLowPrice = array.size(allSwingLows) > 0 ? array.get(allSwingLows, array.size(allSwingLows) - 1) : na
+    isHigherLow = not na(lastLowPrice) and swingLowPrice > lastLowPrice
+    isLowerLow = not na(lastLowPrice) and swingLowPrice < lastLowPrice
+
+    array.push(allSwingLows, swingLowPrice)
+    array.push(allSwingLowBars, swingBarIndex)
+    array.push(allSwingLowIsLower, isLowerLow)
+    array.push(allSwingLowIsIntermediate, false)
+
+    drawLineNow = showShortTermSwings
+    drawPrice = swingLowPrice
+    drawBar = swingBarIndex
+
+    if isHigherLow and array.size(allSwingLows) > 1
+        prevLowIndex = array.size(allSwingLows) - 2
+        if array.get(allSwingLowIsLower, prevLowIndex)
+            array.set(allSwingLowIsIntermediate, prevLowIndex, true)
+            if not showShortTermSwings
+                drawLineNow := true
+                drawPrice := array.get(allSwingLows, prevLowIndex)
+                drawBar := array.get(allSwingLowBars, prevLowIndex)
+
+    if drawLineNow
+        lowLine = line.new(drawBar, drawPrice, bar_index, drawPrice, xloc=xloc.bar_index, extend=extend.right, color=colorLow, style=selectedLineStyle, width=lineWidth)
+        array.unshift(swingLowLines, lowLine)
+        array.unshift(swingLowLabels, na)
+        array.unshift(swingLowPrices, drawPrice)
+        array.unshift(swingLowBars, drawBar)
+        array.unshift(swingLowIsActive, true)
+        trimLowVisibility(maxVisibleSwings)
 
 // -----------------------------------------------------------------------------
 // Manage high sweeps

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 8, "1", xloc=xloc.bar_index, yloc=yloc.abovebar, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 12, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -152,12 +152,11 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice - syminfo.mintick * 8
+                lowLabelY = lowLevelPrice - syminfo.mintick * 12
                 if na(lowLabelId)
-                    newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.abovebar, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+                    newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
                 else
-                    label.set_yloc(lowLabelId, yloc.abovebar)
                     label.set_xy(lowLabelId, lowLabelX, lowLabelY)
                     label.set_text(lowLabelId, str.tostring(lowAge))
                     label.set_textcolor(lowLabelId, lowcolor)
@@ -207,9 +206,8 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice - syminfo.mintick * 8
+                            lowLabelY = lowLevelPrice - syminfo.mintick * 12
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
-                            label.set_yloc(lowLabelId, yloc.abovebar)
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))
                             label.set_textcolor(lowLabelId, lowcolor)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 8, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 6, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -152,7 +152,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice - syminfo.mintick * 8
+                lowLabelY = lowLevelPrice - syminfo.mintick * 6
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -206,7 +206,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice - syminfo.mintick * 8
+                            lowLabelY = lowLevelPrice - syminfo.mintick * 6
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -8,12 +8,15 @@ var inputPivotBars = input(5, "Pivot Candles", group="Liquidity Module")
 var highcolor = input.color(color.rgb(70, 184, 42), "High Color", group="Liquidity Module")
 var lowcolor = input.color(color.rgb(200, 200, 200), "Low Color", group="Liquidity Module")
 var lineWidth = input.int(1, "Line Width", minval=1, maxval=4, group="Liquidity Module")
+var lineStyle = input.string("Solid", "Line Style", options=["Solid", "Dashed", "Dotted"], group="Liquidity Module")
 
 // Fixed variables (not user inputs)
 var bool inputHighlightIntermediates = true
 var bool inputShowShortTermSwings = true
 var string inputIntermediateSize = "Tiny"
 var intermediateLabelSize = size.tiny
+
+lineStyleValue = lineStyle == "Dashed" ? line.style_dashed : lineStyle == "Dotted" ? line.style_dotted : line.style_solid
 
 // Parallel arrays for Swing High Data
 var float[] swingHighs = array.new_float()
@@ -59,14 +62,12 @@ if not na(swingHighPrice)
     lastSwingHighPrice = array_peek(swingHighs)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
-    swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=line.style_solid, width=lineWidth)
+    swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
         // lower high after a higher high means the previous swing high was intermediate
         if inputHighlightIntermediates
-            previousSwingHighLine = array.get(swingHighLines, array.size(swingHighLines) - 1)
-            line.set_width(previousSwingHighLine, lineWidth + 1)
             array.set(swingHighIsIntermediate, array.size(swingHighIsIntermediate) - 1, true)
 
     // save swing
@@ -79,14 +80,12 @@ if not na(swingLowPrice)
     lastSwingLowPrice = array_peek(swingLows)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
-    swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=line.style_solid, width=lineWidth)
+    swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
         // higher low after a lower low means the previous swing low was intermediate
         if inputHighlightIntermediates
-            previousSwingLowLine = array.get(swingLowLines, array.size(swingLowLines) - 1)
-            line.set_width(previousSwingLowLine, lineWidth + 1)
             array.set(swingLowIsIntermediate, array.size(swingLowIsIntermediate) - 1, true)
 
     // save swing

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -1,0 +1,186 @@
+//@version=6
+indicator("Modulo 1: Liquidez (Swings)", shorttitle="M1 Liquidez", overlay=true, max_lines_count=500, max_labels_count=500)
+
+// -----------------------------------------------------------------------------
+// Inputs
+// -----------------------------------------------------------------------------
+groupSwings = "Swings"
+groupLines = "Lineas de Liquidez"
+groupLabels = "Etiquetas de Maduracion"
+
+pivotBars = input.int(5, "Pivot Length", minval=1, group=groupSwings)
+
+colorHigh = input.color(color.red, "Color Swing High", group=groupLines)
+colorLow = input.color(color.green, "Color Swing Low", group=groupLines)
+lineWidth = input.int(1, "Grosor de Linea", minval=1, maxval=4, group=groupLines)
+lineStyleInput = input.string("Solid", "Estilo de Linea", options=["Solid", "Dashed", "Dotted"], group=groupLines)
+
+labelPosition = input.string("Right", "Posicion Etiqueta", options=["Center", "Left", "Right", "Up", "Down"], group=groupLabels)
+labelOffsetX = input.int(0, "Offset X (barras)", group=groupLabels)
+labelOffsetY = input.int(0, "Offset Y (ticks)", group=groupLabels)
+showPriceInLabel = input.bool(false, "Mostrar precio en etiqueta", group=groupLabels)
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+lineStyleFromInput(styleText) =>
+    styleText == "Dashed" ? line.style_dashed : styleText == "Dotted" ? line.style_dotted : line.style_solid
+
+labelStyleFromInput(pos) =>
+    pos == "Left" ? label.style_label_left : pos == "Right" ? label.style_label_right : pos == "Up" ? label.style_label_up : pos == "Down" ? label.style_label_down : label.style_none
+
+labelText(barsAlive, levelPrice, includePrice) =>
+    includePrice ? "V: " + str.tostring(barsAlive) + " | P: " + str.tostring(levelPrice, format.mintick) : "V: " + str.tostring(barsAlive)
+
+labelCoordinates(levelBarIndex, levelPrice, pos, xOffset, yOffsetTicks) =>
+    barsSpan = math.max(bar_index - levelBarIndex, 0)
+    centerBar = levelBarIndex + int(math.floor(barsSpan * 0.5))
+
+    xBase = pos == "Left" ? levelBarIndex : pos == "Center" ? centerBar : bar_index
+    yBase = levelPrice
+    yBase += pos == "Up" ? syminfo.mintick * 2.0 : 0.0
+    yBase -= pos == "Down" ? syminfo.mintick * 2.0 : 0.0
+
+    xFinal = xBase + xOffset
+    yFinal = yBase + (yOffsetTicks * syminfo.mintick)
+    [xFinal, yFinal]
+
+// -----------------------------------------------------------------------------
+// Parallel arrays for highs
+// -----------------------------------------------------------------------------
+var line[] swingHighLines = array.new_line()
+var label[] swingHighLabels = array.new_label()
+var float[] swingHighPrices = array.new_float()
+var int[] swingHighBars = array.new_int()
+var bool[] swingHighIsActive = array.new_bool()
+
+// -----------------------------------------------------------------------------
+// Parallel arrays for lows
+// -----------------------------------------------------------------------------
+var line[] swingLowLines = array.new_line()
+var label[] swingLowLabels = array.new_label()
+var float[] swingLowPrices = array.new_float()
+var int[] swingLowBars = array.new_int()
+var bool[] swingLowIsActive = array.new_bool()
+
+// -----------------------------------------------------------------------------
+// Detect swings
+// -----------------------------------------------------------------------------
+swingHighPrice = ta.pivothigh(high, pivotBars, pivotBars)
+swingLowPrice = ta.pivotlow(low, pivotBars, pivotBars)
+selectedLineStyle = lineStyleFromInput(lineStyleInput)
+selectedLabelStyle = labelStyleFromInput(labelPosition)
+
+if not na(swingHighPrice)
+    swingBarIndex = bar_index - pivotBars
+    highLine = line.new(swingBarIndex, swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=colorHigh, style=selectedLineStyle, width=lineWidth)
+    array.push(swingHighLines, highLine)
+    array.push(swingHighLabels, na)
+    array.push(swingHighPrices, swingHighPrice)
+    array.push(swingHighBars, swingBarIndex)
+    array.push(swingHighIsActive, true)
+
+if not na(swingLowPrice)
+    swingBarIndex = bar_index - pivotBars
+    lowLine = line.new(swingBarIndex, swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=colorLow, style=selectedLineStyle, width=lineWidth)
+    array.push(swingLowLines, lowLine)
+    array.push(swingLowLabels, na)
+    array.push(swingLowPrices, swingLowPrice)
+    array.push(swingLowBars, swingBarIndex)
+    array.push(swingLowIsActive, true)
+
+// -----------------------------------------------------------------------------
+// Manage high sweeps
+// Partial sweep (wick): high >= level and close < level
+// Total sweep (close): close >= level
+// -----------------------------------------------------------------------------
+highCount = array.size(swingHighLines)
+if highCount > 0
+    for i = 0 to highCount - 1
+        isActive = array.get(swingHighIsActive, i)
+        if isActive
+            levelPrice = array.get(swingHighPrices, i)
+            levelBarIndex = array.get(swingHighBars, i)
+            levelLine = array.get(swingHighLines, i)
+            levelLabel = array.get(swingHighLabels, i)
+
+            partialSweep = high >= levelPrice and close < levelPrice
+            totalSweep = close >= levelPrice
+            eventDetected = partialSweep or totalSweep
+
+            if eventDetected
+                barsAlive = math.max(bar_index - levelBarIndex, 0) + 1
+                [labelX, labelY] = labelCoordinates(levelBarIndex, levelPrice, labelPosition, labelOffsetX, labelOffsetY)
+                textValue = labelText(barsAlive, levelPrice, showPriceInLabel)
+
+                if na(levelLabel)
+                    newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=selectedLabelStyle, color=color.new(colorHigh, 65), textcolor=color.white, size=size.tiny)
+                    array.set(swingHighLabels, i, newLabel)
+                else
+                    label.set_x(levelLabel, labelX)
+                    label.set_y(levelLabel, labelY)
+                    label.set_text(levelLabel, textValue)
+                    label.set_style(levelLabel, selectedLabelStyle)
+                    label.set_color(levelLabel, color.new(colorHigh, 65))
+                    label.set_textcolor(levelLabel, color.white)
+
+                if totalSweep
+                    line.delete(levelLine)
+                    array.set(swingHighIsActive, i, false)
+                else
+                    line.set_x2(levelLine, bar_index)
+                    line.set_extend(levelLine, extend.none)
+
+                    replacementPrice = close + syminfo.mintick
+                    replacementLine = line.new(bar_index, replacementPrice, bar_index, replacementPrice, xloc=xloc.bar_index, extend=extend.right, color=colorHigh, style=selectedLineStyle, width=lineWidth)
+                    array.set(swingHighLines, i, replacementLine)
+                    array.set(swingHighPrices, i, replacementPrice)
+                    array.set(swingHighBars, i, bar_index)
+
+// -----------------------------------------------------------------------------
+// Manage low sweeps
+// Partial sweep (wick): low <= level and close > level
+// Total sweep (close): close <= level
+// -----------------------------------------------------------------------------
+lowCount = array.size(swingLowLines)
+if lowCount > 0
+    for i = 0 to lowCount - 1
+        isActive = array.get(swingLowIsActive, i)
+        if isActive
+            levelPrice = array.get(swingLowPrices, i)
+            levelBarIndex = array.get(swingLowBars, i)
+            levelLine = array.get(swingLowLines, i)
+            levelLabel = array.get(swingLowLabels, i)
+
+            partialSweep = low <= levelPrice and close > levelPrice
+            totalSweep = close <= levelPrice
+            eventDetected = partialSweep or totalSweep
+
+            if eventDetected
+                barsAlive = math.max(bar_index - levelBarIndex, 0) + 1
+                [labelX, labelY] = labelCoordinates(levelBarIndex, levelPrice, labelPosition, labelOffsetX, labelOffsetY)
+                textValue = labelText(barsAlive, levelPrice, showPriceInLabel)
+
+                if na(levelLabel)
+                    newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=selectedLabelStyle, color=color.new(colorLow, 65), textcolor=color.white, size=size.tiny)
+                    array.set(swingLowLabels, i, newLabel)
+                else
+                    label.set_x(levelLabel, labelX)
+                    label.set_y(levelLabel, labelY)
+                    label.set_text(levelLabel, textValue)
+                    label.set_style(levelLabel, selectedLabelStyle)
+                    label.set_color(levelLabel, color.new(colorLow, 65))
+                    label.set_textcolor(levelLabel, color.white)
+
+                if totalSweep
+                    line.delete(levelLine)
+                    array.set(swingLowIsActive, i, false)
+                else
+                    line.set_x2(levelLine, bar_index)
+                    line.set_extend(levelLine, extend.none)
+
+                    replacementPrice = close - syminfo.mintick
+                    replacementLine = line.new(bar_index, replacementPrice, bar_index, replacementPrice, xloc=xloc.bar_index, extend=extend.right, color=colorLow, style=selectedLineStyle, width=lineWidth)
+                    array.set(swingLowLines, i, replacementLine)
+                    array.set(swingLowPrices, i, replacementPrice)
+                    array.set(swingLowBars, i, bar_index)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -1,7 +1,7 @@
 // This source code is subject to the terms of the Mozilla Public License 2.0 at https://mozilla.org/MPL/2.0/
 
 //@version=5
-indicator("M1 Liquidez (Swings)", shorttitle="M1 Liquidity", overlay=true, max_lines_count=500)
+indicator("M1 Liquidez (Swings)", shorttitle="M1 Liquidity", overlay=true, max_lines_count=500, max_labels_count=500)
 
 // === Liquidity Module Settings ===
 var inputPivotBars = input(5, "Pivot Candles", group="Liquidity Module")
@@ -9,6 +9,9 @@ var highcolor = input.color(color.rgb(70, 184, 42), "Swing High Color", group="L
 var lowcolor = input.color(color.rgb(200, 200, 200), "Swing Low Color", group="Liquidity Module")
 var lineWidth = input.int(1, "Line Width", minval=1, maxval=4, group="Liquidity Module")
 var lineStyle = input.string("Solid", "Line Style", options=["Solid", "Dashed", "Dotted"], group="Liquidity Module")
+var labelSize = input.string("Tiny", "Label Size", options=["Tiny", "Small", "Normal"], group="Liquidity Module")
+var labelOffsetY = input.int(2, "Label Vertical Offset (ticks)", minval=0, maxval=10, group="Liquidity Module")
+var labelOffsetX = input.int(-1, "Label Horizontal Offset (bars)", minval=-10, maxval=10, group="Liquidity Module")
 
 // Fixed variables (not user inputs)
 var bool inputHighlightIntermediates = true
@@ -17,10 +20,12 @@ var string inputIntermediateSize = "Tiny"
 var intermediateLabelSize = size.tiny
 
 lineStyleValue = lineStyle == "Dashed" ? line.style_dashed : lineStyle == "Dotted" ? line.style_dotted : line.style_solid
+selectedLabelSize = labelSize == "Small" ? size.small : labelSize == "Normal" ? size.normal : size.tiny
 
 // Parallel arrays for Swing High Data
 var float[] swingHighs = array.new_float()
 var line[] swingHighLines = array.new_line()
+var label[] swingHighLabels = array.new_label()
 var bool[] swingHighIsHigher = array.new_bool()
 var bool[] swingHighIsIntermediate = array.new_bool()
 var bool[] swingHighSwept = array.new_bool()
@@ -28,6 +33,7 @@ var bool[] swingHighSwept = array.new_bool()
 // Parallel arrays for Swing Low Data
 var float[] swingLows = array.new_float()
 var line[] swingLowLines = array.new_line()
+var label[] swingLowLabels = array.new_label()
 var bool[] swingLowIsLower = array.new_bool()
 var bool[] swingLowIsIntermediate = array.new_bool()
 var bool[] swingLowSwept = array.new_bool()
@@ -49,10 +55,16 @@ remove_short_term_swings() =>
         for i = 0 to swingHighCount - 1 by 1
             if not array.get(swingHighIsIntermediate, i)
                 line.delete(array.get(swingHighLines, i))
+                swingHighLabel = array.get(swingHighLabels, i)
+                if not na(swingHighLabel)
+                    label.delete(swingHighLabel)
 
         for i = 0 to swingLowCount - 1 by 1
             if not array.get(swingLowIsIntermediate, i)
                 line.delete(array.get(swingLowLines, i))
+                swingLowLabel = array.get(swingLowLabels, i)
+                if not na(swingLowLabel)
+                    label.delete(swingLowLabel)
 
 
 // detect swing highs and lows
@@ -65,6 +77,7 @@ if not na(swingHighPrice)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
     swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
+    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice + syminfo.mintick * labelOffsetY, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -75,6 +88,7 @@ if not na(swingHighPrice)
     // save swing
     array.push(swingHighs, swingHighPrice)
     array.push(swingHighLines, swingLine)
+    array.push(swingHighLabels, swingLabel)
     array.push(swingHighIsHigher, isHigherHigh)
     array.push(swingHighIsIntermediate, false) // can be filled in later, if a lower high forms next
     array.push(swingHighSwept, false)
@@ -84,6 +98,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * labelOffsetY, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -94,12 +109,61 @@ if not na(swingLowPrice)
     // save swing
     array.push(swingLows, swingLowPrice)
     array.push(swingLowLines, swingLine)
+    array.push(swingLowLabels, swingLabel)
     array.push(swingLowIsLower, isLowerLow)
     array.push(swingLowIsIntermediate, false) // can be filled in later if a higher low forms next
     array.push(swingLowSwept, false)
 
 
 remove_short_term_swings()
+
+// Update age labels for active liquidity lines.
+if barstate.isnew
+    int swingHighLabelCount = array.size(swingHighLines)
+    if swingHighLabelCount > 0
+        for i = 0 to swingHighLabelCount - 1 by 1
+            line highLineId = array.get(swingHighLines, i)
+            label highLabelId = array.get(swingHighLabels, i)
+            bool highWasSwept = array.get(swingHighSwept, i)
+            if not na(highLineId) and not highWasSwept
+                highLevelPrice = line.get_y1(highLineId)
+                highLevelBar = line.get_x1(highLineId)
+                highAge = bar_index - highLevelBar + 1
+                highLabelX = bar_index + labelOffsetX
+                highLabelY = highLevelPrice + syminfo.mintick * labelOffsetY
+                if na(highLabelId)
+                    newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
+                    array.set(swingHighLabels, i, newHighLabel)
+                else
+                    label.set_xy(highLabelId, highLabelX, highLabelY)
+                    label.set_text(highLabelId, str.tostring(highAge))
+                    label.set_textcolor(highLabelId, highcolor)
+                    label.set_size(highLabelId, selectedLabelSize)
+                    label.set_style(highLabelId, label.style_none)
+                    label.set_color(highLabelId, color.new(color.white, 100))
+
+    int swingLowLabelCount = array.size(swingLowLines)
+    if swingLowLabelCount > 0
+        for i = 0 to swingLowLabelCount - 1 by 1
+            line lowLineId = array.get(swingLowLines, i)
+            label lowLabelId = array.get(swingLowLabels, i)
+            bool lowWasSwept = array.get(swingLowSwept, i)
+            if not na(lowLineId) and not lowWasSwept
+                lowLevelPrice = line.get_y1(lowLineId)
+                lowLevelBar = line.get_x1(lowLineId)
+                lowAge = bar_index - lowLevelBar + 1
+                lowLabelX = bar_index + labelOffsetX
+                lowLabelY = lowLevelPrice - syminfo.mintick * labelOffsetY
+                if na(lowLabelId)
+                    newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+                    array.set(swingLowLabels, i, newLowLabel)
+                else
+                    label.set_xy(lowLabelId, lowLabelX, lowLabelY)
+                    label.set_text(lowLabelId, str.tostring(lowAge))
+                    label.set_textcolor(lowLabelId, lowcolor)
+                    label.set_size(lowLabelId, selectedLabelSize)
+                    label.set_style(lowLabelId, label.style_none)
+                    label.set_color(lowLabelId, color.new(color.white, 100))
 
 // Sweep management: cut line when price touches/exceeds the liquidity level.
 if barstate.isconfirmed
@@ -113,6 +177,10 @@ if barstate.isconfirmed
                 if line.get_x2(highLineId) < bar_index
                     highLevelPrice = line.get_y1(highLineId)
                     if high >= highLevelPrice
+                        highLabelId = array.get(swingHighLabels, i)
+                        if not na(highLabelId)
+                            label.delete(highLabelId)
+                            array.set(swingHighLabels, i, na)
                         line.set_x2(highLineId, bar_index)
                         line.set_extend(highLineId, extend.none)
                         array.set(swingHighSwept, i, true)
@@ -127,6 +195,10 @@ if barstate.isconfirmed
                 if line.get_x2(lowLineId) < bar_index
                     lowLevelPrice = line.get_y1(lowLineId)
                     if low <= lowLevelPrice
+                        lowLabelId = array.get(swingLowLabels, i)
+                        if not na(lowLabelId)
+                            label.delete(lowLabelId)
+                            array.set(swingLowLabels, i, na)
                         line.set_x2(lowLineId, bar_index)
                         line.set_extend(lowLineId, extend.none)
                         array.set(swingLowSwept, i, true)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 5, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 2, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -152,7 +152,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice - syminfo.mintick * 5
+                lowLabelY = lowLevelPrice - syminfo.mintick * 2
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -206,7 +206,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice - syminfo.mintick * 5
+                            lowLabelY = lowLevelPrice - syminfo.mintick * 2
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -15,10 +15,7 @@ colorLow = input.color(color.green, "Color Swing Low", group=groupLines)
 lineWidth = input.int(1, "Grosor de Linea", minval=1, maxval=4, group=groupLines)
 lineStyleInput = input.string("Solid", "Estilo de Linea", options=["Solid", "Dashed", "Dotted"], group=groupLines)
 
-labelPosition = input.string("Right", "Posicion Etiqueta", options=["Center", "Left", "Right", "Up", "Down"], group=groupLabels)
-labelOffsetX = input.int(0, "Offset X (barras)", group=groupLabels)
-labelOffsetY = input.int(0, "Offset Y (ticks)", group=groupLabels)
-showPriceInLabel = input.bool(false, "Mostrar precio en etiqueta", group=groupLabels)
+labelTextSize = input.string(size.tiny, "Tamano Texto Etiqueta", options=[size.auto, size.tiny, size.small, size.normal], group=groupLabels)
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -26,24 +23,8 @@ showPriceInLabel = input.bool(false, "Mostrar precio en etiqueta", group=groupLa
 lineStyleFromInput(styleText) =>
     styleText == "Dashed" ? line.style_dashed : styleText == "Dotted" ? line.style_dotted : line.style_solid
 
-labelStyleFromInput(pos) =>
-    pos == "Left" ? label.style_label_left : pos == "Right" ? label.style_label_right : pos == "Up" ? label.style_label_up : pos == "Down" ? label.style_label_down : label.style_none
-
-labelText(barsAlive, levelPrice, includePrice) =>
-    includePrice ? "V: " + str.tostring(barsAlive) + " | P: " + str.tostring(levelPrice, format.mintick) : "V: " + str.tostring(barsAlive)
-
-labelCoordinates(levelBarIndex, levelPrice, pos, xOffset, yOffsetTicks) =>
-    barsSpan = math.max(bar_index - levelBarIndex, 0)
-    centerBar = levelBarIndex + int(math.floor(barsSpan * 0.5))
-
-    xBase = pos == "Left" ? levelBarIndex : pos == "Center" ? centerBar : bar_index
-    yBase = levelPrice
-    yBase += pos == "Up" ? syminfo.mintick * 2.0 : 0.0
-    yBase -= pos == "Down" ? syminfo.mintick * 2.0 : 0.0
-
-    xFinal = xBase + xOffset
-    yFinal = yBase + (yOffsetTicks * syminfo.mintick)
-    [xFinal, yFinal]
+labelText(barsAlive) =>
+    str.tostring(barsAlive)
 
 // -----------------------------------------------------------------------------
 // Parallel arrays for highs
@@ -69,7 +50,6 @@ var bool[] swingLowIsActive = array.new_bool()
 swingHighPrice = ta.pivothigh(high, pivotBars, pivotBars)
 swingLowPrice = ta.pivotlow(low, pivotBars, pivotBars)
 selectedLineStyle = lineStyleFromInput(lineStyleInput)
-selectedLabelStyle = labelStyleFromInput(labelPosition)
 
 if not na(swingHighPrice)
     swingBarIndex = bar_index - pivotBars
@@ -104,28 +84,37 @@ if highCount > 0
             levelLine = array.get(swingHighLines, i)
             levelLabel = array.get(swingHighLabels, i)
 
+            // Keep matured labels anchored to the right edge while line is active.
+            if not na(levelLabel)
+                label.set_x(levelLabel, bar_index)
+                label.set_y(levelLabel, levelPrice + syminfo.mintick * 2.0)
+
             partialSweep = high >= levelPrice and close < levelPrice
             totalSweep = close >= levelPrice
             eventDetected = partialSweep or totalSweep
 
             if eventDetected
                 barsAlive = math.max(bar_index - levelBarIndex, 0) + 1
-                [labelX, labelY] = labelCoordinates(levelBarIndex, levelPrice, labelPosition, labelOffsetX, labelOffsetY)
-                textValue = labelText(barsAlive, levelPrice, showPriceInLabel)
+                labelX = bar_index
+                labelY = levelPrice + syminfo.mintick * 2.0
+                textValue = labelText(barsAlive)
 
                 if na(levelLabel)
-                    newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=selectedLabelStyle, color=color.new(colorHigh, 65), textcolor=color.white, size=size.tiny)
+                    newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=colorHigh, size=labelTextSize, text_formatting=text.format_bold)
                     array.set(swingHighLabels, i, newLabel)
                 else
                     label.set_x(levelLabel, labelX)
                     label.set_y(levelLabel, labelY)
                     label.set_text(levelLabel, textValue)
-                    label.set_style(levelLabel, selectedLabelStyle)
-                    label.set_color(levelLabel, color.new(colorHigh, 65))
-                    label.set_textcolor(levelLabel, color.white)
+                    label.set_style(levelLabel, label.style_none)
+                    label.set_color(levelLabel, color.new(color.white, 100))
+                    label.set_textcolor(levelLabel, colorHigh)
+                    label.set_size(levelLabel, labelTextSize)
+                    label.set_text_formatting(levelLabel, text.format_bold)
 
                 if totalSweep
-                    line.delete(levelLine)
+                    line.set_x2(levelLine, bar_index)
+                    line.set_extend(levelLine, extend.none)
                     array.set(swingHighIsActive, i, false)
                 else
                     line.set_x2(levelLine, bar_index)
@@ -152,28 +141,37 @@ if lowCount > 0
             levelLine = array.get(swingLowLines, i)
             levelLabel = array.get(swingLowLabels, i)
 
+            // Keep matured labels anchored to the right edge while line is active.
+            if not na(levelLabel)
+                label.set_x(levelLabel, bar_index)
+                label.set_y(levelLabel, levelPrice - syminfo.mintick * 2.0)
+
             partialSweep = low <= levelPrice and close > levelPrice
             totalSweep = close <= levelPrice
             eventDetected = partialSweep or totalSweep
 
             if eventDetected
                 barsAlive = math.max(bar_index - levelBarIndex, 0) + 1
-                [labelX, labelY] = labelCoordinates(levelBarIndex, levelPrice, labelPosition, labelOffsetX, labelOffsetY)
-                textValue = labelText(barsAlive, levelPrice, showPriceInLabel)
+                labelX = bar_index
+                labelY = levelPrice - syminfo.mintick * 2.0
+                textValue = labelText(barsAlive)
 
                 if na(levelLabel)
-                    newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=selectedLabelStyle, color=color.new(colorLow, 65), textcolor=color.white, size=size.tiny)
+                    newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=colorLow, size=labelTextSize, text_formatting=text.format_bold)
                     array.set(swingLowLabels, i, newLabel)
                 else
                     label.set_x(levelLabel, labelX)
                     label.set_y(levelLabel, labelY)
                     label.set_text(levelLabel, textValue)
-                    label.set_style(levelLabel, selectedLabelStyle)
-                    label.set_color(levelLabel, color.new(colorLow, 65))
-                    label.set_textcolor(levelLabel, color.white)
+                    label.set_style(levelLabel, label.style_none)
+                    label.set_color(levelLabel, color.new(color.white, 100))
+                    label.set_textcolor(levelLabel, colorLow)
+                    label.set_size(levelLabel, labelTextSize)
+                    label.set_text_formatting(levelLabel, text.format_bold)
 
                 if totalSweep
-                    line.delete(levelLine)
+                    line.set_x2(levelLine, bar_index)
+                    line.set_extend(levelLine, extend.none)
                     array.set(swingLowIsActive, i, false)
                 else
                     line.set_x2(levelLine, bar_index)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -5,19 +5,21 @@ indicator("M1 Liquidez (Swings)", shorttitle="M1 Liquidity", overlay=true, max_l
 
 // === Liquidity Module Settings ===
 var inputPivotBars = input(5, "Pivot Candles", group="Liquidity Module")
-var highcolor = input.color(color.rgb(70, 184, 42), "Swing High Color", group="Liquidity Module")
-var lowcolor = input.color(color.rgb(200, 200, 200), "Swing Low Color", group="Liquidity Module")
+var highcolor = input.color(color.rgb(184, 184, 184), "Swing High Color", group="Liquidity Module")
+var lowcolor = input.color(color.rgb(76, 175, 80), "Swing Low Color", group="Liquidity Module")
 var lineWidth = input.int(1, "Line Width", minval=1, maxval=4, group="Liquidity Module")
 var lineStyle = input.string("Solid", "Line Style", options=["Solid", "Dashed", "Dotted"], group="Liquidity Module")
 var labelSize = input.string("Tiny", "Label Size", options=["Tiny", "Small", "Normal"], group="Liquidity Module")
-var labelOffsetY = input.int(2, "Label Vertical Offset (ticks)", minval=0, maxval=10, group="Liquidity Module")
-var labelOffsetX = input.int(-1, "Label Horizontal Offset (bars)", minval=-10, maxval=10, group="Liquidity Module")
+var labelOffsetX = input.int(-2, "Label Horizontal Offset (bars)", minval=-10, maxval=10, group="Liquidity Module")
 
 // Fixed variables (not user inputs)
 var bool inputHighlightIntermediates = true
 var bool inputShowShortTermSwings = true
 var string inputIntermediateSize = "Tiny"
 var intermediateLabelSize = size.tiny
+var int labelOffsetY = 0
+var int highLabelOffsetTicks = 2
+var int lowLabelOffsetTicks = -2
 
 lineStyleValue = lineStyle == "Dashed" ? line.style_dashed : lineStyle == "Dotted" ? line.style_dotted : line.style_solid
 selectedLabelSize = labelSize == "Small" ? size.small : labelSize == "Normal" ? size.normal : size.tiny
@@ -77,7 +79,7 @@ if not na(swingHighPrice)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
     swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice + syminfo.mintick * labelOffsetY, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice + syminfo.mintick * highLabelOffsetTicks, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -98,7 +100,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * labelOffsetY, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice + syminfo.mintick * lowLabelOffsetTicks, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -130,7 +132,7 @@ if barstate.isnew
                 highLevelBar = line.get_x1(highLineId)
                 highAge = bar_index - highLevelBar + 1
                 highLabelX = line.get_x2(highLineId) + labelOffsetX
-                highLabelY = highLevelPrice + syminfo.mintick * labelOffsetY
+                highLabelY = highLevelPrice + syminfo.mintick * highLabelOffsetTicks
                 if na(highLabelId)
                     newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
                     array.set(swingHighLabels, i, newHighLabel)
@@ -153,7 +155,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice - syminfo.mintick * labelOffsetY
+                lowLabelY = lowLevelPrice + syminfo.mintick * lowLabelOffsetTicks
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -182,9 +184,9 @@ if barstate.isconfirmed
                         line.set_extend(highLineId, extend.none)
                         if not na(highLabelId)
                             highLabelX = bar_index + labelOffsetX
-                            highLabelY = highLevelPrice + syminfo.mintick * labelOffsetY
+                            highLabelY = highLevelPrice + syminfo.mintick * highLabelOffsetTicks
                             highAge = bar_index - line.get_x1(highLineId) + 1
-                            label.set_xy(highLabelId, highLabelX, highLabelY)
+                            label.set_xy(highLabelId, line.get_x2(highLineId) + labelOffsetX, highLabelY)
                             label.set_text(highLabelId, str.tostring(highAge))
                             label.set_textcolor(highLabelId, highcolor)
                             label.set_size(highLabelId, selectedLabelSize)
@@ -207,9 +209,9 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice - syminfo.mintick * labelOffsetY
+                            lowLabelY = lowLevelPrice + syminfo.mintick * lowLabelOffsetTicks
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
-                            label.set_xy(lowLabelId, lowLabelX, lowLabelY)
+                            label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))
                             label.set_textcolor(lowLabelId, lowcolor)
                             label.set_size(lowLabelId, selectedLabelSize)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -129,7 +129,7 @@ if barstate.isnew
                 highLevelPrice = line.get_y1(highLineId)
                 highLevelBar = line.get_x1(highLineId)
                 highAge = bar_index - highLevelBar + 1
-                highLabelX = bar_index + labelOffsetX
+                highLabelX = line.get_x2(highLineId) + labelOffsetX
                 highLabelY = highLevelPrice + syminfo.mintick * labelOffsetY
                 if na(highLabelId)
                     newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
@@ -152,7 +152,7 @@ if barstate.isnew
                 lowLevelPrice = line.get_y1(lowLineId)
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
-                lowLabelX = bar_index + labelOffsetX
+                lowLabelX = line.get_x2(lowLineId) + labelOffsetX
                 lowLabelY = lowLevelPrice - syminfo.mintick * labelOffsetY
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
@@ -178,11 +178,18 @@ if barstate.isconfirmed
                     highLevelPrice = line.get_y1(highLineId)
                     if high >= highLevelPrice
                         highLabelId = array.get(swingHighLabels, i)
-                        if not na(highLabelId)
-                            label.delete(highLabelId)
-                            array.set(swingHighLabels, i, na)
                         line.set_x2(highLineId, bar_index)
                         line.set_extend(highLineId, extend.none)
+                        if not na(highLabelId)
+                            highLabelX = bar_index + labelOffsetX
+                            highLabelY = highLevelPrice + syminfo.mintick * labelOffsetY
+                            highAge = bar_index - line.get_x1(highLineId) + 1
+                            label.set_xy(highLabelId, highLabelX, highLabelY)
+                            label.set_text(highLabelId, str.tostring(highAge))
+                            label.set_textcolor(highLabelId, highcolor)
+                            label.set_size(highLabelId, selectedLabelSize)
+                            label.set_style(highLabelId, label.style_none)
+                            label.set_color(highLabelId, color.new(color.white, 100))
                         array.set(swingHighSwept, i, true)
 
     int swingLowCount = array.size(swingLowLines)
@@ -196,9 +203,16 @@ if barstate.isconfirmed
                     lowLevelPrice = line.get_y1(lowLineId)
                     if low <= lowLevelPrice
                         lowLabelId = array.get(swingLowLabels, i)
-                        if not na(lowLabelId)
-                            label.delete(lowLabelId)
-                            array.set(swingLowLabels, i, na)
                         line.set_x2(lowLineId, bar_index)
                         line.set_extend(lowLineId, extend.none)
+                        if not na(lowLabelId)
+                            lowLabelX = bar_index + labelOffsetX
+                            lowLabelY = lowLevelPrice - syminfo.mintick * labelOffsetY
+                            lowAge = bar_index - line.get_x1(lowLineId) + 1
+                            label.set_xy(lowLabelId, lowLabelX, lowLabelY)
+                            label.set_text(lowLabelId, str.tostring(lowAge))
+                            label.set_textcolor(lowLabelId, lowcolor)
+                            label.set_size(lowLabelId, selectedLabelSize)
+                            label.set_style(lowLabelId, label.style_none)
+                            label.set_color(lowLabelId, color.new(color.white, 100))
                         array.set(swingLowSwept, i, true)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -10,7 +10,6 @@ var lowcolor = input.color(color.rgb(76, 175, 80), "Swing Low Color", group="Liq
 var lineWidth = input.int(1, "Line Width", minval=1, maxval=4, group="Liquidity Module")
 var lineStyle = input.string("Solid", "Line Style", options=["Solid", "Dashed", "Dotted"], group="Liquidity Module")
 var labelSize = input.string("Tiny", "Label Size", options=["Tiny", "Small", "Normal"], group="Liquidity Module")
-var labelOffsetX = input.int(-2, "Label Horizontal Offset (bars)", minval=-10, maxval=10, group="Liquidity Module")
 
 // Fixed variables (not user inputs)
 var bool inputHighlightIntermediates = true
@@ -76,7 +75,7 @@ if not na(swingHighPrice)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
     swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index - 2, swingHighPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -97,7 +96,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index - 2, swingLowPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -128,7 +127,7 @@ if barstate.isnew
                 highLevelPrice = line.get_y1(highLineId)
                 highLevelBar = line.get_x1(highLineId)
                 highAge = bar_index - highLevelBar + 1
-                highLabelX = line.get_x2(highLineId) + labelOffsetX
+                highLabelX = line.get_x2(highLineId) - 2
                 highLabelY = highLevelPrice
                 if na(highLabelId)
                     newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
@@ -151,7 +150,7 @@ if barstate.isnew
                 lowLevelPrice = line.get_y1(lowLineId)
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
-                lowLabelX = line.get_x2(lowLineId) + labelOffsetX
+                lowLabelX = line.get_x2(lowLineId) - 2
                 lowLabelY = lowLevelPrice
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
@@ -180,10 +179,10 @@ if barstate.isconfirmed
                         line.set_x2(highLineId, bar_index)
                         line.set_extend(highLineId, extend.none)
                         if not na(highLabelId)
-                            highLabelX = bar_index + labelOffsetX
+                            highLabelX = bar_index - 2
                             highLabelY = highLevelPrice
                             highAge = bar_index - line.get_x1(highLineId) + 1
-                            label.set_xy(highLabelId, line.get_x2(highLineId) + labelOffsetX, highLabelY)
+                            label.set_xy(highLabelId, line.get_x2(highLineId) - 2, highLabelY)
                             label.set_text(highLabelId, str.tostring(highAge))
                             label.set_textcolor(highLabelId, highcolor)
                             label.set_size(highLabelId, selectedLabelSize)
@@ -205,10 +204,10 @@ if barstate.isconfirmed
                         line.set_x2(lowLineId, bar_index)
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
-                            lowLabelX = bar_index + labelOffsetX
+                            lowLabelX = bar_index - 2
                             lowLabelY = lowLevelPrice
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
-                            label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
+                            label.set_xy(lowLabelId, line.get_x2(lowLineId) - 2, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))
                             label.set_textcolor(lowLabelId, lowcolor)
                             label.set_size(lowLabelId, selectedLabelSize)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -1,230 +1,95 @@
+// This source code is subject to the terms of the Mozilla Public License 2.0 at https://mozilla.org/MPL/2.0/
 //@version=6
-indicator("Modulo 1: Liquidez (Swings)", shorttitle="M1 Liquidez", overlay=true, max_lines_count=500, max_labels_count=500)
+indicator("Modulo 1: Liquidez (Swings)", overlay=true, max_lines_count=500)
 
-// -----------------------------------------------------------------------------
-// Inputs
-// -----------------------------------------------------------------------------
-groupSwings = "Swings"
-groupLines = "Lineas de Liquidez"
-groupLabels = "Etiquetas de Maduracion"
+var inputHighlightIntermediates = input.bool(true, "Highlight Intermediate Swing Highs and Lows")
+var inputIntermediateSize = input.string("Tiny", "Intermediate Swing Label Size", options=["Auto", "Tiny", "Small", "Normal"])
+var inputShowShortTermSwings = input.bool(false, "Short Term Swings")
+var inputPivotBars = input.int(2, "Pivot Candles", minval=1)
+var highcolor = input.color(color.red, title="High", tooltip="Select a color for ST/IT highs")
+var lowcolor = input.color(color.green, title="Low", tooltip="Select a color for ST/IT lows")
+var lineWidth = input.int(1, "Line Width", minval=1, maxval=4)
 
-pivotBars = input.int(3, "Pivot Length", minval=1, group=groupSwings)
-maxVisibleSwings = input.int(100, "Max Sweeps Visibles", minval=10, maxval=500, group=groupSwings)
+// Kept for compatibility with the original script inputs.
+var intermediateLabelSize = inputIntermediateSize == "Auto" ? size.auto : inputIntermediateSize == "Tiny" ? size.tiny : inputIntermediateSize == "Small" ? size.small : size.normal
 
-colorHigh = input.color(color.red, "Color Swing High", group=groupLines)
-colorLow = input.color(color.green, "Color Swing Low", group=groupLines)
-lineWidth = input.int(1, "Grosor de Linea", minval=1, maxval=4, group=groupLines)
-lineStyleInput = input.string("Solid", "Estilo de Linea", options=["Solid", "Dashed", "Dotted"], group=groupLines)
+intermediateLineWidth = inputIntermediateSize == "Auto" ? lineWidth : inputIntermediateSize == "Tiny" ? lineWidth : inputIntermediateSize == "Small" ? math.min(4, lineWidth + 1) : math.min(4, lineWidth + 2)
 
-minBarsForLabel = input.int(3, "Mostrar etiqueta solo si Velas >= ", minval=1, group=groupLabels)
-
-// -----------------------------------------------------------------------------
-// Helpers
-// -----------------------------------------------------------------------------
-lineStyleFromInput(styleText) =>
-    styleText == "Dashed" ? line.style_dashed : styleText == "Dotted" ? line.style_dotted : line.style_solid
-
-labelText(barsAlive) =>
-    str.tostring(barsAlive)
-
-labelTextSize = size.tiny
-labelXOffsetBars = -1
-highLabelOffsetTicks = 3.0
-lowLabelOffsetTicks = -3.0
-
-// -----------------------------------------------------------------------------
-// Parallel arrays for highs
-// -----------------------------------------------------------------------------
+// Parallel arrays for Swing High Data
+var float[] swingHighs = array.new_float()
 var line[] swingHighLines = array.new_line()
-var label[] swingHighLabels = array.new_label()
-var float[] swingHighPrices = array.new_float()
-var int[] swingHighBars = array.new_int()
-var bool[] swingHighIsActive = array.new_bool()
+var bool[] swingHighIsHigher = array.new_bool()
+var bool[] swingHighIsIntermediate = array.new_bool()
 
-// -----------------------------------------------------------------------------
-// Parallel arrays for lows
-// -----------------------------------------------------------------------------
+// Parallel arrays for Swing Low Data
+var float[] swingLows = array.new_float()
 var line[] swingLowLines = array.new_line()
-var label[] swingLowLabels = array.new_label()
-var float[] swingLowPrices = array.new_float()
-var int[] swingLowBars = array.new_int()
-var bool[] swingLowIsActive = array.new_bool()
+var bool[] swingLowIsLower = array.new_bool()
+var bool[] swingLowIsIntermediate = array.new_bool()
 
-trimHighVisibility(maxItems) =>
-    while array.size(swingHighLines) > maxItems
-        oldLine = array.pop(swingHighLines)
-        oldLabel = array.pop(swingHighLabels)
-        array.pop(swingHighPrices)
-        array.pop(swingHighBars)
-        array.pop(swingHighIsActive)
-        line.delete(oldLine)
-        if not na(oldLabel)
-            label.delete(oldLabel)
+// See last element pushed in an array.
+array_peek(arrayId) =>
+    int arraySize = array.size(arrayId)
+    if arraySize > 0
+        array.get(arrayId, arraySize - 1)
+    else
+        na
 
-trimLowVisibility(maxItems) =>
-    while array.size(swingLowLines) > maxItems
-        oldLine = array.pop(swingLowLines)
-        oldLabel = array.pop(swingLowLabels)
-        array.pop(swingLowPrices)
-        array.pop(swingLowBars)
-        array.pop(swingLowIsActive)
-        line.delete(oldLine)
-        if not na(oldLabel)
-            label.delete(oldLabel)
+// Filters out swings that were not intermediate swings after all swings have been recorded.
+remove_short_term_swings() =>
+    if not inputShowShortTermSwings and barstate.islast
+        int swingHighCount = array.size(swingHighLines)
+        int swingLowCount = array.size(swingLowLines)
 
-// -----------------------------------------------------------------------------
-// Detect swings
-// -----------------------------------------------------------------------------
-swingHighPrice = ta.pivothigh(high, pivotBars, pivotBars)
-swingLowPrice = ta.pivotlow(low, pivotBars, pivotBars)
-selectedLineStyle = lineStyleFromInput(lineStyleInput)
+        for i = 0 to swingHighCount - 1 by 1
+            if not array.get(swingHighIsIntermediate, i)
+                line.delete(array.get(swingHighLines, i))
+
+        for i = 0 to swingLowCount - 1 by 1
+            if not array.get(swingLowIsIntermediate, i)
+                line.delete(array.get(swingLowLines, i))
+
+
+// Detect swing highs and lows.
+swingHighPrice = ta.pivothigh(high, inputPivotBars, inputPivotBars)
+swingLowPrice = ta.pivotlow(low, inputPivotBars, inputPivotBars)
 
 if not na(swingHighPrice)
-    swingBarIndex = bar_index - pivotBars
-    highLine = line.new(swingBarIndex, swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=colorHigh, style=selectedLineStyle, width=lineWidth)
-    array.unshift(swingHighLines, highLine)
-    array.unshift(swingHighLabels, na)
-    array.unshift(swingHighPrices, swingHighPrice)
-    array.unshift(swingHighBars, swingBarIndex)
-    array.unshift(swingHighIsActive, true)
-    trimHighVisibility(maxVisibleSwings)
+    lastSwingHighPrice = array_peek(swingHighs)
+    isHigherHigh = swingHighPrice > lastSwingHighPrice
+    isLowerHigh = swingHighPrice < lastSwingHighPrice
+    swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=line.style_solid, width=lineWidth)
+
+    // Check if last swing high was intermediate.
+    if isLowerHigh and array_peek(swingHighIsHigher)
+        // Lower high after a higher high means the previous swing high was intermediate.
+        if inputHighlightIntermediates
+            line.set_width(array_peek(swingHighLines), intermediateLineWidth)
+            array.set(swingHighIsIntermediate, array.size(swingHighIsIntermediate) - 1, true)
+
+    // Save swing.
+    array.push(swingHighs, swingHighPrice)
+    array.push(swingHighLines, swingLine)
+    array.push(swingHighIsHigher, isHigherHigh)
+    array.push(swingHighIsIntermediate, false) // Can be filled in later, if a lower high forms next.
 
 if not na(swingLowPrice)
-    swingBarIndex = bar_index - pivotBars
-    lowLine = line.new(swingBarIndex, swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=colorLow, style=selectedLineStyle, width=lineWidth)
-    array.unshift(swingLowLines, lowLine)
-    array.unshift(swingLowLabels, na)
-    array.unshift(swingLowPrices, swingLowPrice)
-    array.unshift(swingLowBars, swingBarIndex)
-    array.unshift(swingLowIsActive, true)
-    trimLowVisibility(maxVisibleSwings)
+    lastSwingLowPrice = array_peek(swingLows)
+    isHigherLow = swingLowPrice > lastSwingLowPrice
+    isLowerLow = swingLowPrice < lastSwingLowPrice
+    swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=line.style_solid, width=lineWidth)
 
-// -----------------------------------------------------------------------------
-// Manage high sweeps
-// Partial sweep (wick): high >= level and close < level
-// Total sweep (close): close >= level
-// -----------------------------------------------------------------------------
-highCount = array.size(swingHighLines)
-if highCount > 0
-    for i = 0 to highCount - 1
-        isActive = array.get(swingHighIsActive, i)
-        if isActive
-            levelPrice = array.get(swingHighPrices, i)
-            levelBarIndex = array.get(swingHighBars, i)
-            levelLine = array.get(swingHighLines, i)
-            levelLabel = array.get(swingHighLabels, i)
+    // Check if last swing low was intermediate.
+    if isHigherLow and array_peek(swingLowIsLower)
+        // Higher low after a lower low means the previous swing low was intermediate.
+        if inputHighlightIntermediates
+            line.set_width(array_peek(swingLowLines), intermediateLineWidth)
+            array.set(swingLowIsIntermediate, array.size(swingLowIsIntermediate) - 1, true)
 
-            labelX = bar_index + labelXOffsetBars
-            labelY = levelPrice + syminfo.mintick * highLabelOffsetTicks
+    // Save swing.
+    array.push(swingLows, swingLowPrice)
+    array.push(swingLowLines, swingLine)
+    array.push(swingLowIsLower, isLowerLow)
+    array.push(swingLowIsIntermediate, false) // Can be filled in later if a higher low forms next.
 
-            // Keep matured labels anchored to the selected line position while active.
-            if not na(levelLabel)
-                label.set_x(levelLabel, labelX)
-                label.set_y(levelLabel, labelY)
-
-            partialSweep = high >= levelPrice and close < levelPrice
-            totalSweep = close >= levelPrice
-            eventDetected = partialSweep or totalSweep
-
-            if eventDetected
-                barsAlive = math.max(bar_index - levelBarIndex, 0) + 1
-                textValue = labelText(barsAlive)
-
-                if barsAlive >= minBarsForLabel
-                    if na(levelLabel)
-                        newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=colorHigh, size=labelTextSize, text_formatting=text.format_bold)
-                        array.set(swingHighLabels, i, newLabel)
-                    else
-                        label.set_x(levelLabel, labelX)
-                        label.set_y(levelLabel, labelY)
-                        label.set_text(levelLabel, textValue)
-                        label.set_style(levelLabel, label.style_none)
-                        label.set_color(levelLabel, color.new(color.white, 100))
-                        label.set_textcolor(levelLabel, colorHigh)
-                        label.set_size(levelLabel, labelTextSize)
-                        label.set_text_formatting(levelLabel, text.format_bold)
-
-                if totalSweep
-                    line.set_x2(levelLine, bar_index)
-                    line.set_extend(levelLine, extend.none)
-                    if not na(levelLabel)
-                        label.delete(levelLabel)
-                        array.set(swingHighLabels, i, na)
-                    array.set(swingHighIsActive, i, false)
-                else
-                    line.set_x2(levelLine, bar_index)
-                    line.set_extend(levelLine, extend.none)
-
-                    replacementPrice = close + syminfo.mintick
-                    replacementLine = line.new(bar_index, replacementPrice, bar_index, replacementPrice, xloc=xloc.bar_index, extend=extend.right, color=colorHigh, style=selectedLineStyle, width=lineWidth)
-                    if not na(levelLabel)
-                        label.delete(levelLabel)
-                    array.set(swingHighLabels, i, na)
-                    array.set(swingHighLines, i, replacementLine)
-                    array.set(swingHighPrices, i, replacementPrice)
-                    array.set(swingHighBars, i, bar_index)
-
-// -----------------------------------------------------------------------------
-// Manage low sweeps
-// Partial sweep (wick): low <= level and close > level
-// Total sweep (close): close <= level
-// -----------------------------------------------------------------------------
-lowCount = array.size(swingLowLines)
-if lowCount > 0
-    for i = 0 to lowCount - 1
-        isActive = array.get(swingLowIsActive, i)
-        if isActive
-            levelPrice = array.get(swingLowPrices, i)
-            levelBarIndex = array.get(swingLowBars, i)
-            levelLine = array.get(swingLowLines, i)
-            levelLabel = array.get(swingLowLabels, i)
-
-            labelX = bar_index + labelXOffsetBars
-            labelY = levelPrice + syminfo.mintick * lowLabelOffsetTicks
-
-            // Keep matured labels anchored to the selected line position while active.
-            if not na(levelLabel)
-                label.set_x(levelLabel, labelX)
-                label.set_y(levelLabel, labelY)
-
-            partialSweep = low <= levelPrice and close > levelPrice
-            totalSweep = close <= levelPrice
-            eventDetected = partialSweep or totalSweep
-
-            if eventDetected
-                barsAlive = math.max(bar_index - levelBarIndex, 0) + 1
-                textValue = labelText(barsAlive)
-
-                if barsAlive >= minBarsForLabel
-                    if na(levelLabel)
-                        newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=colorLow, size=labelTextSize, text_formatting=text.format_bold)
-                        array.set(swingLowLabels, i, newLabel)
-                    else
-                        label.set_x(levelLabel, labelX)
-                        label.set_y(levelLabel, labelY)
-                        label.set_text(levelLabel, textValue)
-                        label.set_style(levelLabel, label.style_none)
-                        label.set_color(levelLabel, color.new(color.white, 100))
-                        label.set_textcolor(levelLabel, colorLow)
-                        label.set_size(levelLabel, labelTextSize)
-                        label.set_text_formatting(levelLabel, text.format_bold)
-
-                if totalSweep
-                    line.set_x2(levelLine, bar_index)
-                    line.set_extend(levelLine, extend.none)
-                    if not na(levelLabel)
-                        label.delete(levelLabel)
-                        array.set(swingLowLabels, i, na)
-                    array.set(swingLowIsActive, i, false)
-                else
-                    line.set_x2(levelLine, bar_index)
-                    line.set_extend(levelLine, extend.none)
-
-                    replacementPrice = close - syminfo.mintick
-                    replacementLine = line.new(bar_index, replacementPrice, bar_index, replacementPrice, xloc=xloc.bar_index, extend=extend.right, color=colorLow, style=selectedLineStyle, width=lineWidth)
-                    if not na(levelLabel)
-                        label.delete(levelLabel)
-                    array.set(swingLowLabels, i, na)
-                    array.set(swingLowLines, i, replacementLine)
-                    array.set(swingLowPrices, i, replacementPrice)
-                    array.set(swingLowBars, i, bar_index)
+remove_short_term_swings()

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 2, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 5, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -152,7 +152,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice - syminfo.mintick * 2
+                lowLabelY = lowLevelPrice - syminfo.mintick * 5
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -206,7 +206,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice - syminfo.mintick * 2
+                            lowLabelY = lowLevelPrice - syminfo.mintick * 5
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 5, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 6, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -152,7 +152,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice - syminfo.mintick * 5
+                lowLabelY = lowLevelPrice - syminfo.mintick * 6
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -206,7 +206,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice - syminfo.mintick * 5
+                            lowLabelY = lowLevelPrice - syminfo.mintick * 6
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -1,109 +1,94 @@
 // This source code is subject to the terms of the Mozilla Public License 2.0 at https://mozilla.org/MPL/2.0/
-//@version=6
-indicator("Modulo 1: Liquidez (Swings)", overlay=true, max_lines_count=500)
 
-var inputHighlightIntermediates = input.bool(true, "Highlight Intermediate Swing Highs and Lows")
+//@version=5
+indicator("M1 Liquidez (Swings)", overlay=true, max_labels_count=500)
+
+var inputHighlightIntermediates = input(true, "Highlight Intermediate Swing Highs and Lows")
 var inputIntermediateSize = input.string("Tiny", "Intermediate Swing Label Size", options=["Auto", "Tiny", "Small", "Normal"])
-var inputShowShortTermSwings = input.bool(false, "Short Term Swings")
-var inputPivotBars = input.int(2, "Pivot Candles", minval=1)
-var highcolor = input.color(color.red, title="High", tooltip="Select a color for ST/IT highs")
-var lowcolor = input.color(color.green, title="Low", tooltip="Select a color for ST/IT lows")
-var lineWidth = input.int(1, "Line Width", minval=1, maxval=4)
+var inputShowShortTermSwings = input(false, "Short Term Swings")
+var inputPivotBars = input(2, "Pivot Candles")
+var highcolor = input.color(color.red, title="High", tooltip="select a color for ST/IT Highs")
+var lowcolor = input.color(color.green, title="Low", tooltip="select a color for ST/IT Lows")
 
-// Kept for compatibility with the original script inputs.
 var intermediateLabelSize = inputIntermediateSize == "Auto" ? size.auto : inputIntermediateSize == "Tiny" ? size.tiny : inputIntermediateSize == "Small" ? size.small : size.normal
-
-intermediateLineWidth = inputIntermediateSize == "Auto" ? lineWidth : inputIntermediateSize == "Tiny" ? lineWidth : inputIntermediateSize == "Small" ? math.min(4, lineWidth + 1) : math.min(4, lineWidth + 2)
 
 // Parallel arrays for Swing High Data
 var float[] swingHighs = array.new_float()
-var line[] swingHighLines = array.new_line()
+var label[] swingHighLabels = array.new_label()
 var bool[] swingHighIsHigher = array.new_bool()
 var bool[] swingHighIsIntermediate = array.new_bool()
 
 // Parallel arrays for Swing Low Data
 var float[] swingLows = array.new_float()
-var line[] swingLowLines = array.new_line()
+var label[] swingLowLabels = array.new_label()
 var bool[] swingLowIsLower = array.new_bool()
 var bool[] swingLowIsIntermediate = array.new_bool()
 
-// See last element pushed in typed arrays.
-array_peek_float(float[] arrayId) =>
+// see last element pushed an an array
+array_peek(arrayId) =>
     int arraySize = array.size(arrayId)
     if arraySize > 0
         array.get(arrayId, arraySize - 1)
     else
         na
 
-array_peek_bool(bool[] arrayId) =>
-    int arraySize = array.size(arrayId)
-    if arraySize > 0
-        array.get(arrayId, arraySize - 1)
-    else
-        false
-
-array_peek_line(line[] arrayId) =>
-    int arraySize = array.size(arrayId)
-    if arraySize > 0
-        array.get(arrayId, arraySize - 1)
-    else
-        na
-
-// Filters out swings that were not intermediate swings after all swings have been recorded.
+// filters out swings that were not intermediate swings after all swings have been recorded.
 remove_short_term_swings() =>
     if not inputShowShortTermSwings and barstate.islast
-        int swingHighCount = array.size(swingHighLines)
-        int swingLowCount = array.size(swingLowLines)
+        var swingHighCount = array.size(swingHighLabels)
+        var swingLowCount = array.size(swingLowLabels)
 
         for i = 0 to swingHighCount - 1 by 1
             if not array.get(swingHighIsIntermediate, i)
-                line.delete(array.get(swingHighLines, i))
+                label.delete(array.get(swingHighLabels, i))
 
         for i = 0 to swingLowCount - 1 by 1
             if not array.get(swingLowIsIntermediate, i)
-                line.delete(array.get(swingLowLines, i))
+                label.delete(array.get(swingLowLabels, i))
 
 
-// Detect swing highs and lows.
+// detect swing highs and lows
 swingHighPrice = ta.pivothigh(high, inputPivotBars, inputPivotBars)
 swingLowPrice = ta.pivotlow(low, inputPivotBars, inputPivotBars)
 
+
 if not na(swingHighPrice)
-    lastSwingHighPrice = array_peek_float(swingHighs)
+    lastSwingHighPrice = array_peek(swingHighs)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
-    swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=line.style_solid, width=lineWidth)
+    swingLabel = label.new(bar_index[inputPivotBars], swingHighPrice, color=highcolor, yloc=yloc.price, style=label.style_circle, size=size.tiny)
 
-    // Check if last swing high was intermediate.
-    if isLowerHigh and array_peek_bool(swingHighIsHigher)
-        // Lower high after a higher high means the previous swing high was intermediate.
+    // check if last swing high was intermediate
+    if isLowerHigh and array_peek(swingHighIsHigher)
+        // lower high after a higher high means the previous swing high was intermediate
         if inputHighlightIntermediates
-            line.set_width(array_peek_line(swingHighLines), intermediateLineWidth)
+            label.set_size(array_peek(swingHighLabels), intermediateLabelSize)
             array.set(swingHighIsIntermediate, array.size(swingHighIsIntermediate) - 1, true)
 
-    // Save swing.
+    // save swing
     array.push(swingHighs, swingHighPrice)
-    array.push(swingHighLines, swingLine)
+    array.push(swingHighLabels, swingLabel)
     array.push(swingHighIsHigher, isHigherHigh)
-    array.push(swingHighIsIntermediate, false) // Can be filled in later, if a lower high forms next.
+    array.push(swingHighIsIntermediate, false) // can be filled in later, if a lower high forms next
 
 if not na(swingLowPrice)
-    lastSwingLowPrice = array_peek_float(swingLows)
+    lastSwingLowPrice = array_peek(swingLows)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
-    swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=line.style_solid, width=lineWidth)
+    swingLabel = label.new(bar_index[inputPivotBars], swingLowPrice, color=lowcolor, yloc=yloc.price, style=label.style_circle, size=size.tiny)
 
-    // Check if last swing low was intermediate.
-    if isHigherLow and array_peek_bool(swingLowIsLower)
-        // Higher low after a lower low means the previous swing low was intermediate.
+    // check if last swing low was intermediate
+    if isHigherLow and array_peek(swingLowIsLower)
+        // higher low after a lower low means the previous swing low was intermediate
         if inputHighlightIntermediates
-            line.set_width(array_peek_line(swingLowLines), intermediateLineWidth)
+            label.set_size(array_peek(swingLowLabels), intermediateLabelSize)
             array.set(swingLowIsIntermediate, array.size(swingLowIsIntermediate) - 1, true)
 
-    // Save swing.
+    // save swing
     array.push(swingLows, swingLowPrice)
-    array.push(swingLowLines, swingLine)
+    array.push(swingLowLabels, swingLabel)
     array.push(swingLowIsLower, isLowerLow)
-    array.push(swingLowIsIntermediate, false) // Can be filled in later if a higher low forms next.
+    array.push(swingLowIsIntermediate, false) // can be filled in later if a higher low forms next
+
 
 remove_short_term_swings()

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 12, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -152,7 +152,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice - syminfo.mintick * 12
+                lowLabelY = lowLevelPrice
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -206,7 +206,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice - syminfo.mintick * 12
+                            lowLabelY = lowLevelPrice
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -17,6 +17,7 @@ lineStyleInput = input.string("Solid", "Estilo de Linea", options=["Solid", "Das
 
 labelTextSize = input.string(size.tiny, "Tamano Texto Etiqueta", options=[size.auto, size.tiny, size.small, size.normal], group=groupLabels)
 labelPosition = input.string("Right", "Posicion Etiqueta", options=["Center", "Left", "Right"], group=groupLabels)
+labelOffsetX = input.int(0, "Offset X de Etiqueta (barras)", group=groupLabels)
 minBarsForLabel = input.int(5, "Mostrar etiqueta solo si Velas >= ", minval=1, group=groupLabels)
 
 // -----------------------------------------------------------------------------
@@ -32,6 +33,11 @@ labelXByPosition(levelBarIndex, currentBarIndex, pos) =>
     barsSpan = math.max(currentBarIndex - levelBarIndex, 0)
     centerBar = levelBarIndex + int(math.floor(barsSpan * 0.5))
     pos == "Left" ? levelBarIndex : pos == "Center" ? centerBar : currentBarIndex
+
+labelXWithOffset(levelBarIndex, currentBarIndex, pos, xOffset) =>
+    xBase = labelXByPosition(levelBarIndex, currentBarIndex, pos)
+    xWithOffset = xBase + xOffset
+    pos == "Center" ? math.min(math.max(xWithOffset, levelBarIndex), currentBarIndex) : xWithOffset
 
 // -----------------------------------------------------------------------------
 // Parallel arrays for highs
@@ -91,7 +97,7 @@ if highCount > 0
             levelLine = array.get(swingHighLines, i)
             levelLabel = array.get(swingHighLabels, i)
 
-            labelX = labelXByPosition(levelBarIndex, bar_index, labelPosition)
+            labelX = labelXWithOffset(levelBarIndex, bar_index, labelPosition, labelOffsetX)
             labelY = levelPrice + syminfo.mintick * 5.0
 
             // Keep matured labels anchored to the selected line position while active.
@@ -156,7 +162,7 @@ if lowCount > 0
             levelLine = array.get(swingLowLines, i)
             levelLabel = array.get(swingLowLabels, i)
 
-            labelX = labelXByPosition(levelBarIndex, bar_index, labelPosition)
+            labelX = labelXWithOffset(levelBarIndex, bar_index, labelPosition, labelOffsetX)
             labelY = levelPrice - syminfo.mintick * 5.0
 
             // Keep matured labels anchored to the selected line position while active.

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -16,6 +16,8 @@ lineWidth = input.int(1, "Grosor de Linea", minval=1, maxval=4, group=groupLines
 lineStyleInput = input.string("Solid", "Estilo de Linea", options=["Solid", "Dashed", "Dotted"], group=groupLines)
 
 labelTextSize = input.string(size.tiny, "Tamano Texto Etiqueta", options=[size.auto, size.tiny, size.small, size.normal], group=groupLabels)
+labelPosition = input.string("Right", "Posicion Etiqueta", options=["Center", "Left", "Right"], group=groupLabels)
+minBarsForLabel = input.int(5, "Mostrar etiqueta solo si Velas >= ", minval=1, group=groupLabels)
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -25,6 +27,11 @@ lineStyleFromInput(styleText) =>
 
 labelText(barsAlive) =>
     str.tostring(barsAlive)
+
+labelXByPosition(levelBarIndex, currentBarIndex, pos) =>
+    barsSpan = math.max(currentBarIndex - levelBarIndex, 0)
+    centerBar = levelBarIndex + int(math.floor(barsSpan * 0.5))
+    pos == "Left" ? levelBarIndex : pos == "Center" ? centerBar : currentBarIndex
 
 // -----------------------------------------------------------------------------
 // Parallel arrays for highs
@@ -84,10 +91,13 @@ if highCount > 0
             levelLine = array.get(swingHighLines, i)
             levelLabel = array.get(swingHighLabels, i)
 
-            // Keep matured labels anchored to the right edge while line is active.
+            labelX = labelXByPosition(levelBarIndex, bar_index, labelPosition)
+            labelY = levelPrice + syminfo.mintick * 5.0
+
+            // Keep matured labels anchored to the selected line position while active.
             if not na(levelLabel)
-                label.set_x(levelLabel, bar_index)
-                label.set_y(levelLabel, levelPrice + syminfo.mintick * 2.0)
+                label.set_x(levelLabel, labelX)
+                label.set_y(levelLabel, labelY)
 
             partialSweep = high >= levelPrice and close < levelPrice
             totalSweep = close >= levelPrice
@@ -95,26 +105,28 @@ if highCount > 0
 
             if eventDetected
                 barsAlive = math.max(bar_index - levelBarIndex, 0) + 1
-                labelX = bar_index
-                labelY = levelPrice + syminfo.mintick * 2.0
                 textValue = labelText(barsAlive)
 
-                if na(levelLabel)
-                    newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=colorHigh, size=labelTextSize, text_formatting=text.format_bold)
-                    array.set(swingHighLabels, i, newLabel)
-                else
-                    label.set_x(levelLabel, labelX)
-                    label.set_y(levelLabel, labelY)
-                    label.set_text(levelLabel, textValue)
-                    label.set_style(levelLabel, label.style_none)
-                    label.set_color(levelLabel, color.new(color.white, 100))
-                    label.set_textcolor(levelLabel, colorHigh)
-                    label.set_size(levelLabel, labelTextSize)
-                    label.set_text_formatting(levelLabel, text.format_bold)
+                if barsAlive >= minBarsForLabel
+                    if na(levelLabel)
+                        newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=colorHigh, size=labelTextSize, text_formatting=text.format_bold)
+                        array.set(swingHighLabels, i, newLabel)
+                    else
+                        label.set_x(levelLabel, labelX)
+                        label.set_y(levelLabel, labelY)
+                        label.set_text(levelLabel, textValue)
+                        label.set_style(levelLabel, label.style_none)
+                        label.set_color(levelLabel, color.new(color.white, 100))
+                        label.set_textcolor(levelLabel, colorHigh)
+                        label.set_size(levelLabel, labelTextSize)
+                        label.set_text_formatting(levelLabel, text.format_bold)
 
                 if totalSweep
                     line.set_x2(levelLine, bar_index)
                     line.set_extend(levelLine, extend.none)
+                    if not na(levelLabel)
+                        label.delete(levelLabel)
+                        array.set(swingHighLabels, i, na)
                     array.set(swingHighIsActive, i, false)
                 else
                     line.set_x2(levelLine, bar_index)
@@ -122,6 +134,9 @@ if highCount > 0
 
                     replacementPrice = close + syminfo.mintick
                     replacementLine = line.new(bar_index, replacementPrice, bar_index, replacementPrice, xloc=xloc.bar_index, extend=extend.right, color=colorHigh, style=selectedLineStyle, width=lineWidth)
+                    if not na(levelLabel)
+                        label.delete(levelLabel)
+                    array.set(swingHighLabels, i, na)
                     array.set(swingHighLines, i, replacementLine)
                     array.set(swingHighPrices, i, replacementPrice)
                     array.set(swingHighBars, i, bar_index)
@@ -141,10 +156,13 @@ if lowCount > 0
             levelLine = array.get(swingLowLines, i)
             levelLabel = array.get(swingLowLabels, i)
 
-            // Keep matured labels anchored to the right edge while line is active.
+            labelX = labelXByPosition(levelBarIndex, bar_index, labelPosition)
+            labelY = levelPrice - syminfo.mintick * 5.0
+
+            // Keep matured labels anchored to the selected line position while active.
             if not na(levelLabel)
-                label.set_x(levelLabel, bar_index)
-                label.set_y(levelLabel, levelPrice - syminfo.mintick * 2.0)
+                label.set_x(levelLabel, labelX)
+                label.set_y(levelLabel, labelY)
 
             partialSweep = low <= levelPrice and close > levelPrice
             totalSweep = close <= levelPrice
@@ -152,26 +170,28 @@ if lowCount > 0
 
             if eventDetected
                 barsAlive = math.max(bar_index - levelBarIndex, 0) + 1
-                labelX = bar_index
-                labelY = levelPrice - syminfo.mintick * 2.0
                 textValue = labelText(barsAlive)
 
-                if na(levelLabel)
-                    newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=colorLow, size=labelTextSize, text_formatting=text.format_bold)
-                    array.set(swingLowLabels, i, newLabel)
-                else
-                    label.set_x(levelLabel, labelX)
-                    label.set_y(levelLabel, labelY)
-                    label.set_text(levelLabel, textValue)
-                    label.set_style(levelLabel, label.style_none)
-                    label.set_color(levelLabel, color.new(color.white, 100))
-                    label.set_textcolor(levelLabel, colorLow)
-                    label.set_size(levelLabel, labelTextSize)
-                    label.set_text_formatting(levelLabel, text.format_bold)
+                if barsAlive >= minBarsForLabel
+                    if na(levelLabel)
+                        newLabel = label.new(labelX, labelY, textValue, xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=colorLow, size=labelTextSize, text_formatting=text.format_bold)
+                        array.set(swingLowLabels, i, newLabel)
+                    else
+                        label.set_x(levelLabel, labelX)
+                        label.set_y(levelLabel, labelY)
+                        label.set_text(levelLabel, textValue)
+                        label.set_style(levelLabel, label.style_none)
+                        label.set_color(levelLabel, color.new(color.white, 100))
+                        label.set_textcolor(levelLabel, colorLow)
+                        label.set_size(levelLabel, labelTextSize)
+                        label.set_text_formatting(levelLabel, text.format_bold)
 
                 if totalSweep
                     line.set_x2(levelLine, bar_index)
                     line.set_extend(levelLine, extend.none)
+                    if not na(levelLabel)
+                        label.delete(levelLabel)
+                        array.set(swingLowLabels, i, na)
                     array.set(swingLowIsActive, i, false)
                 else
                     line.set_x2(levelLine, bar_index)
@@ -179,6 +199,9 @@ if lowCount > 0
 
                     replacementPrice = close - syminfo.mintick
                     replacementLine = line.new(bar_index, replacementPrice, bar_index, replacementPrice, xloc=xloc.bar_index, extend=extend.right, color=colorLow, style=selectedLineStyle, width=lineWidth)
+                    if not na(levelLabel)
+                        label.delete(levelLabel)
+                    array.set(swingLowLabels, i, na)
                     array.set(swingLowLines, i, replacementLine)
                     array.set(swingLowPrices, i, replacementPrice)
                     array.set(swingLowBars, i, bar_index)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 6, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 8, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -152,7 +152,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice - syminfo.mintick * 6
+                lowLabelY = lowLevelPrice - syminfo.mintick * 8
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -206,7 +206,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice - syminfo.mintick * 6
+                            lowLabelY = lowLevelPrice - syminfo.mintick * 8
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -76,7 +76,7 @@ if not na(swingHighPrice)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
     swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice + syminfo.mintick * 2, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice + syminfo.mintick * 5, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 2, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 5, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -129,7 +129,7 @@ if barstate.isnew
                 highLevelBar = line.get_x1(highLineId)
                 highAge = bar_index - highLevelBar + 1
                 highLabelX = line.get_x2(highLineId) + labelOffsetX
-                highLabelY = highLevelPrice + syminfo.mintick * 2
+                highLabelY = highLevelPrice + syminfo.mintick * 5
                 if na(highLabelId)
                     newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
                     array.set(swingHighLabels, i, newHighLabel)
@@ -152,7 +152,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice - syminfo.mintick * 2
+                lowLabelY = lowLevelPrice - syminfo.mintick * 5
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -181,7 +181,7 @@ if barstate.isconfirmed
                         line.set_extend(highLineId, extend.none)
                         if not na(highLabelId)
                             highLabelX = bar_index + labelOffsetX
-                            highLabelY = highLevelPrice + syminfo.mintick * 2
+                            highLabelY = highLevelPrice + syminfo.mintick * 5
                             highAge = bar_index - line.get_x1(highLineId) + 1
                             label.set_xy(highLabelId, line.get_x2(highLineId) + labelOffsetX, highLabelY)
                             label.set_text(highLabelId, str.tostring(highAge))
@@ -206,7 +206,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice - syminfo.mintick * 2
+                            lowLabelY = lowLevelPrice - syminfo.mintick * 5
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -1,5 +1,5 @@
 //@version=6
-indicator("Modulo 1: Liquidez (Swings)", shorttitle="M1 Liquidez", overlay=true, max_lines_count=500, max_labels_count=500)
+indicator("Modulo 1: Liquidez (Swings)", shorttitle="M1 Liquidez", overlay=true, max_lines_count=5000, max_labels_count=5000)
 
 // -----------------------------------------------------------------------------
 // Inputs
@@ -9,16 +9,14 @@ groupLines = "Lineas de Liquidez"
 groupLabels = "Etiquetas de Maduracion"
 
 pivotBars = input.int(5, "Pivot Length", minval=1, group=groupSwings)
+maxVisibleSwings = input.int(100, "Max Sweeps Visibles", minval=10, maxval=5000, group=groupSwings)
 
 colorHigh = input.color(color.red, "Color Swing High", group=groupLines)
 colorLow = input.color(color.green, "Color Swing Low", group=groupLines)
 lineWidth = input.int(1, "Grosor de Linea", minval=1, maxval=4, group=groupLines)
 lineStyleInput = input.string("Solid", "Estilo de Linea", options=["Solid", "Dashed", "Dotted"], group=groupLines)
 
-labelTextSize = input.string(size.tiny, "Tamano Texto Etiqueta", options=[size.auto, size.tiny, size.small, size.normal], group=groupLabels)
-labelPosition = input.string("Right", "Posicion Etiqueta", options=["Center", "Left", "Right"], group=groupLabels)
-labelOffsetX = input.int(0, "Offset X de Etiqueta (barras)", group=groupLabels)
-minBarsForLabel = input.int(5, "Mostrar etiqueta solo si Velas >= ", minval=1, group=groupLabels)
+minBarsForLabel = input.int(3, "Mostrar etiqueta solo si Velas >= ", minval=1, group=groupLabels)
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -29,15 +27,10 @@ lineStyleFromInput(styleText) =>
 labelText(barsAlive) =>
     str.tostring(barsAlive)
 
-labelXByPosition(levelBarIndex, currentBarIndex, pos) =>
-    barsSpan = math.max(currentBarIndex - levelBarIndex, 0)
-    centerBar = levelBarIndex + int(math.floor(barsSpan * 0.5))
-    pos == "Left" ? levelBarIndex : pos == "Center" ? centerBar : currentBarIndex
-
-labelXWithOffset(levelBarIndex, currentBarIndex, pos, xOffset) =>
-    xBase = labelXByPosition(levelBarIndex, currentBarIndex, pos)
-    xWithOffset = xBase + xOffset
-    pos == "Center" ? math.min(math.max(xWithOffset, levelBarIndex), currentBarIndex) : xWithOffset
+labelTextSize = size.tiny
+labelXOffsetBars = -1
+highLabelOffsetTicks = 3.0
+lowLabelOffsetTicks = -3.0
 
 // -----------------------------------------------------------------------------
 // Parallel arrays for highs
@@ -57,6 +50,28 @@ var float[] swingLowPrices = array.new_float()
 var int[] swingLowBars = array.new_int()
 var bool[] swingLowIsActive = array.new_bool()
 
+trimHighVisibility(maxItems) =>
+    while array.size(swingHighLines) > maxItems
+        oldLine = array.pop(swingHighLines)
+        oldLabel = array.pop(swingHighLabels)
+        array.pop(swingHighPrices)
+        array.pop(swingHighBars)
+        array.pop(swingHighIsActive)
+        line.delete(oldLine)
+        if not na(oldLabel)
+            label.delete(oldLabel)
+
+trimLowVisibility(maxItems) =>
+    while array.size(swingLowLines) > maxItems
+        oldLine = array.pop(swingLowLines)
+        oldLabel = array.pop(swingLowLabels)
+        array.pop(swingLowPrices)
+        array.pop(swingLowBars)
+        array.pop(swingLowIsActive)
+        line.delete(oldLine)
+        if not na(oldLabel)
+            label.delete(oldLabel)
+
 // -----------------------------------------------------------------------------
 // Detect swings
 // -----------------------------------------------------------------------------
@@ -67,20 +82,22 @@ selectedLineStyle = lineStyleFromInput(lineStyleInput)
 if not na(swingHighPrice)
     swingBarIndex = bar_index - pivotBars
     highLine = line.new(swingBarIndex, swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=colorHigh, style=selectedLineStyle, width=lineWidth)
-    array.push(swingHighLines, highLine)
-    array.push(swingHighLabels, na)
-    array.push(swingHighPrices, swingHighPrice)
-    array.push(swingHighBars, swingBarIndex)
-    array.push(swingHighIsActive, true)
+    array.unshift(swingHighLines, highLine)
+    array.unshift(swingHighLabels, na)
+    array.unshift(swingHighPrices, swingHighPrice)
+    array.unshift(swingHighBars, swingBarIndex)
+    array.unshift(swingHighIsActive, true)
+    trimHighVisibility(maxVisibleSwings)
 
 if not na(swingLowPrice)
     swingBarIndex = bar_index - pivotBars
     lowLine = line.new(swingBarIndex, swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=colorLow, style=selectedLineStyle, width=lineWidth)
-    array.push(swingLowLines, lowLine)
-    array.push(swingLowLabels, na)
-    array.push(swingLowPrices, swingLowPrice)
-    array.push(swingLowBars, swingBarIndex)
-    array.push(swingLowIsActive, true)
+    array.unshift(swingLowLines, lowLine)
+    array.unshift(swingLowLabels, na)
+    array.unshift(swingLowPrices, swingLowPrice)
+    array.unshift(swingLowBars, swingBarIndex)
+    array.unshift(swingLowIsActive, true)
+    trimLowVisibility(maxVisibleSwings)
 
 // -----------------------------------------------------------------------------
 // Manage high sweeps
@@ -97,8 +114,8 @@ if highCount > 0
             levelLine = array.get(swingHighLines, i)
             levelLabel = array.get(swingHighLabels, i)
 
-            labelX = labelXWithOffset(levelBarIndex, bar_index, labelPosition, labelOffsetX)
-            labelY = levelPrice + syminfo.mintick * 5.0
+            labelX = bar_index + labelXOffsetBars
+            labelY = levelPrice + syminfo.mintick * highLabelOffsetTicks
 
             // Keep matured labels anchored to the selected line position while active.
             if not na(levelLabel)
@@ -162,8 +179,8 @@ if lowCount > 0
             levelLine = array.get(swingLowLines, i)
             levelLabel = array.get(swingLowLabels, i)
 
-            labelX = labelXWithOffset(levelBarIndex, bar_index, labelPosition, labelOffsetX)
-            labelY = levelPrice - syminfo.mintick * 5.0
+            labelX = bar_index + labelXOffsetBars
+            labelY = levelPrice + syminfo.mintick * lowLabelOffsetTicks
 
             // Keep matured labels anchored to the selected line position while active.
             if not na(levelLabel)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -1,5 +1,5 @@
 //@version=6
-indicator("Modulo 1: Liquidez (Swings)", shorttitle="M1 Liquidez", overlay=true, max_lines_count=5000, max_labels_count=5000)
+indicator("Modulo 1: Liquidez (Swings)", shorttitle="M1 Liquidez", overlay=true, max_lines_count=500, max_labels_count=500)
 
 // -----------------------------------------------------------------------------
 // Inputs
@@ -9,7 +9,7 @@ groupLines = "Lineas de Liquidez"
 groupLabels = "Etiquetas de Maduracion"
 
 pivotBars = input.int(5, "Pivot Length", minval=1, group=groupSwings)
-maxVisibleSwings = input.int(100, "Max Sweeps Visibles", minval=10, maxval=5000, group=groupSwings)
+maxVisibleSwings = input.int(100, "Max Sweeps Visibles", minval=10, maxval=500, group=groupSwings)
 
 colorHigh = input.color(color.red, "Color Swing High", group=groupLines)
 colorLow = input.color(color.green, "Color Swing Low", group=groupLines)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -9,7 +9,6 @@ var highcolor = input.color(color.rgb(70, 184, 42), "Swing High Color", group="L
 var lowcolor = input.color(color.rgb(200, 200, 200), "Swing Low Color", group="Liquidity Module")
 var lineWidth = input.int(1, "Line Width", minval=1, maxval=4, group="Liquidity Module")
 var lineStyle = input.string("Solid", "Line Style", options=["Solid", "Dashed", "Dotted"], group="Liquidity Module")
-var deleteOnSweep = input.bool(false, "Delete line after sweep", group="Liquidity Module")
 
 // Fixed variables (not user inputs)
 var bool inputHighlightIntermediates = true
@@ -114,12 +113,8 @@ if barstate.isconfirmed
                 if line.get_x2(highLineId) < bar_index
                     highLevelPrice = line.get_y1(highLineId)
                     if high >= highLevelPrice
-                        if deleteOnSweep
-                            line.delete(highLineId)
-                            array.set(swingHighLines, i, na)
-                        else
-                            line.set_x2(highLineId, bar_index)
-                            line.set_extend(highLineId, extend.none)
+                        line.set_x2(highLineId, bar_index)
+                        line.set_extend(highLineId, extend.none)
                         array.set(swingHighSwept, i, true)
 
     int swingLowCount = array.size(swingLowLines)
@@ -132,10 +127,6 @@ if barstate.isconfirmed
                 if line.get_x2(lowLineId) < bar_index
                     lowLevelPrice = line.get_y1(lowLineId)
                     if low <= lowLevelPrice
-                        if deleteOnSweep
-                            line.delete(lowLineId)
-                            array.set(swingLowLines, i, na)
-                        else
-                            line.set_x2(lowLineId, bar_index)
-                            line.set_extend(lowLineId, extend.none)
+                        line.set_x2(lowLineId, bar_index)
+                        line.set_extend(lowLineId, extend.none)
                         array.set(swingLowSwept, i, true)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -76,7 +76,7 @@ if not na(swingHighPrice)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
     swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice + syminfo.mintick * 5, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 6, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 8, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -129,7 +129,7 @@ if barstate.isnew
                 highLevelBar = line.get_x1(highLineId)
                 highAge = bar_index - highLevelBar + 1
                 highLabelX = line.get_x2(highLineId) + labelOffsetX
-                highLabelY = highLevelPrice + syminfo.mintick * 5
+                highLabelY = highLevelPrice
                 if na(highLabelId)
                     newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
                     array.set(swingHighLabels, i, newHighLabel)
@@ -152,7 +152,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice - syminfo.mintick * 6
+                lowLabelY = lowLevelPrice - syminfo.mintick * 8
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -181,7 +181,7 @@ if barstate.isconfirmed
                         line.set_extend(highLineId, extend.none)
                         if not na(highLabelId)
                             highLabelX = bar_index + labelOffsetX
-                            highLabelY = highLevelPrice + syminfo.mintick * 5
+                            highLabelY = highLevelPrice
                             highAge = bar_index - line.get_x1(highLineId) + 1
                             label.set_xy(highLabelId, line.get_x2(highLineId) + labelOffsetX, highLabelY)
                             label.set_text(highLabelId, str.tostring(highAge))
@@ -206,7 +206,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice - syminfo.mintick * 6
+                            lowLabelY = lowLevelPrice - syminfo.mintick * 8
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -27,6 +27,7 @@ var label[] swingHighLabels = array.new_label()
 var bool[] swingHighIsHigher = array.new_bool()
 var bool[] swingHighIsIntermediate = array.new_bool()
 var bool[] swingHighSwept = array.new_bool()
+var int[] swingHighCreatedBars = array.new_int()
 
 // Parallel arrays for Swing Low Data
 var float[] swingLows = array.new_float()
@@ -35,6 +36,7 @@ var label[] swingLowLabels = array.new_label()
 var bool[] swingLowIsLower = array.new_bool()
 var bool[] swingLowIsIntermediate = array.new_bool()
 var bool[] swingLowSwept = array.new_bool()
+var int[] swingLowCreatedBars = array.new_int()
 
 // see last element pushed an an array
 array_peek(arrayId) =>
@@ -74,7 +76,7 @@ if not na(swingHighPrice)
     lastSwingHighPrice = array_peek(swingHighs)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
-    swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
+    swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.none, color=highcolor, style=lineStyleValue, width=lineWidth)
     swingLabel = label.new(bar_index - 2, swingHighPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
 
     // check if last swing high was intermediate
@@ -90,12 +92,13 @@ if not na(swingHighPrice)
     array.push(swingHighIsHigher, isHigherHigh)
     array.push(swingHighIsIntermediate, false) // can be filled in later, if a lower high forms next
     array.push(swingHighSwept, false)
+    array.push(swingHighCreatedBars, bar_index)
 
 if not na(swingLowPrice)
     lastSwingLowPrice = array_peek(swingLows)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
-    swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
+    swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.none, color=lowcolor, style=lineStyleValue, width=lineWidth)
     swingLabel = label.new(bar_index - 2, swingLowPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
@@ -111,6 +114,7 @@ if not na(swingLowPrice)
     array.push(swingLowIsLower, isLowerLow)
     array.push(swingLowIsIntermediate, false) // can be filled in later if a higher low forms next
     array.push(swingLowSwept, false)
+    array.push(swingLowCreatedBars, bar_index)
 
 
 remove_short_term_swings()
@@ -124,6 +128,8 @@ if barstate.isnew
             label highLabelId = array.get(swingHighLabels, i)
             bool highWasSwept = array.get(swingHighSwept, i)
             if not na(highLineId) and not highWasSwept
+                line.set_x2(highLineId, bar_index)
+                line.set_extend(highLineId, extend.none)
                 highLevelPrice = line.get_y1(highLineId)
                 highLevelBar = line.get_x1(highLineId)
                 highAge = bar_index - highLevelBar + 1
@@ -147,6 +153,8 @@ if barstate.isnew
             label lowLabelId = array.get(swingLowLabels, i)
             bool lowWasSwept = array.get(swingLowSwept, i)
             if not na(lowLineId) and not lowWasSwept
+                line.set_x2(lowLineId, bar_index)
+                line.set_extend(lowLineId, extend.none)
                 lowLevelPrice = line.get_y1(lowLineId)
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
@@ -170,9 +178,10 @@ if barstate.isconfirmed
         for i = 0 to swingHighCount - 1 by 1
             line highLineId = array.get(swingHighLines, i)
             bool highWasSwept = array.get(swingHighSwept, i)
+            int highCreatedBar = array.get(swingHighCreatedBars, i)
             if not highWasSwept and not na(highLineId)
                 // Skip lines that were created on this same bar.
-                if line.get_x2(highLineId) < bar_index
+                if bar_index > highCreatedBar
                     highLevelPrice = line.get_y1(highLineId)
                     if high >= highLevelPrice
                         highLabelId = array.get(swingHighLabels, i)
@@ -195,9 +204,10 @@ if barstate.isconfirmed
         for i = 0 to swingLowCount - 1 by 1
             line lowLineId = array.get(swingLowLines, i)
             bool lowWasSwept = array.get(swingLowSwept, i)
+            int lowCreatedBar = array.get(swingLowCreatedBars, i)
             if not lowWasSwept and not na(lowLineId)
                 // Skip lines that were created on this same bar.
-                if line.get_x2(lowLineId) < bar_index
+                if bar_index > lowCreatedBar
                     lowLevelPrice = line.get_y1(lowLineId)
                     if low <= lowLevelPrice
                         lowLabelId = array.get(swingLowLabels, i)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -97,7 +97,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 8, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice - syminfo.mintick * 8, "1", xloc=xloc.bar_index, yloc=yloc.abovebar, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -154,9 +154,10 @@ if barstate.isnew
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
                 lowLabelY = lowLevelPrice - syminfo.mintick * 8
                 if na(lowLabelId)
-                    newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+                    newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.abovebar, style=label.style_none, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
                 else
+                    label.set_yloc(lowLabelId, yloc.abovebar)
                     label.set_xy(lowLabelId, lowLabelX, lowLabelY)
                     label.set_text(lowLabelId, str.tostring(lowAge))
                     label.set_textcolor(lowLabelId, lowcolor)
@@ -208,6 +209,7 @@ if barstate.isconfirmed
                             lowLabelX = bar_index + labelOffsetX
                             lowLabelY = lowLevelPrice - syminfo.mintick * 8
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
+                            label.set_yloc(lowLabelId, yloc.abovebar)
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))
                             label.set_textcolor(lowLabelId, lowcolor)

--- a/Modulo_1_Liquidez.pine
+++ b/Modulo_1_Liquidez.pine
@@ -11,6 +11,7 @@ var lineWidth = input.int(1, "Line Width", minval=1, maxval=4, group="Liquidity 
 var lineStyle = input.string("Solid", "Line Style", options=["Solid", "Dashed", "Dotted"], group="Liquidity Module")
 var labelSize = input.string("Tiny", "Label Size", options=["Tiny", "Small", "Normal"], group="Liquidity Module")
 var labelOffsetX = input.int(-2, "Label Horizontal Offset (bars)", minval=-10, maxval=10, group="Liquidity Module")
+var labelOffsetY = input.int(0, "Label Vertical Offset (ticks)", minval=-10, maxval=10, group="Liquidity Module")
 
 // Fixed variables (not user inputs)
 var bool inputHighlightIntermediates = true
@@ -76,7 +77,7 @@ if not na(swingHighPrice)
     isHigherHigh = swingHighPrice > lastSwingHighPrice
     isLowerHigh = swingHighPrice < lastSwingHighPrice
     swingLine = line.new(bar_index[inputPivotBars], swingHighPrice, bar_index, swingHighPrice, xloc=xloc.bar_index, extend=extend.right, color=highcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingHighPrice + syminfo.mintick * labelOffsetY, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
 
     // check if last swing high was intermediate
     if isLowerHigh and array_peek(swingHighIsHigher)
@@ -97,7 +98,7 @@ if not na(swingLowPrice)
     isHigherLow = swingLowPrice > lastSwingLowPrice
     isLowerLow = swingLowPrice < lastSwingLowPrice
     swingLine = line.new(bar_index[inputPivotBars], swingLowPrice, bar_index, swingLowPrice, xloc=xloc.bar_index, extend=extend.right, color=lowcolor, style=lineStyleValue, width=lineWidth)
-    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
+    swingLabel = label.new(bar_index + labelOffsetX, swingLowPrice + syminfo.mintick * labelOffsetY, "1", xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
 
     // check if last swing low was intermediate
     if isHigherLow and array_peek(swingLowIsLower)
@@ -129,7 +130,7 @@ if barstate.isnew
                 highLevelBar = line.get_x1(highLineId)
                 highAge = bar_index - highLevelBar + 1
                 highLabelX = line.get_x2(highLineId) + labelOffsetX
-                highLabelY = highLevelPrice
+                highLabelY = highLevelPrice + syminfo.mintick * labelOffsetY
                 if na(highLabelId)
                     newHighLabel = label.new(highLabelX, highLabelY, str.tostring(highAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_down, color=color.new(color.white, 100), textcolor=highcolor, size=selectedLabelSize)
                     array.set(swingHighLabels, i, newHighLabel)
@@ -152,7 +153,7 @@ if barstate.isnew
                 lowLevelBar = line.get_x1(lowLineId)
                 lowAge = bar_index - lowLevelBar + 1
                 lowLabelX = line.get_x2(lowLineId) + labelOffsetX
-                lowLabelY = lowLevelPrice
+                lowLabelY = lowLevelPrice + syminfo.mintick * labelOffsetY
                 if na(lowLabelId)
                     newLowLabel = label.new(lowLabelX, lowLabelY, str.tostring(lowAge), xloc=xloc.bar_index, yloc=yloc.price, style=label.style_label_up, color=color.new(color.white, 100), textcolor=lowcolor, size=selectedLabelSize)
                     array.set(swingLowLabels, i, newLowLabel)
@@ -181,7 +182,7 @@ if barstate.isconfirmed
                         line.set_extend(highLineId, extend.none)
                         if not na(highLabelId)
                             highLabelX = bar_index + labelOffsetX
-                            highLabelY = highLevelPrice
+                            highLabelY = highLevelPrice + syminfo.mintick * labelOffsetY
                             highAge = bar_index - line.get_x1(highLineId) + 1
                             label.set_xy(highLabelId, line.get_x2(highLineId) + labelOffsetX, highLabelY)
                             label.set_text(highLabelId, str.tostring(highAge))
@@ -206,7 +207,7 @@ if barstate.isconfirmed
                         line.set_extend(lowLineId, extend.none)
                         if not na(lowLabelId)
                             lowLabelX = bar_index + labelOffsetX
-                            lowLabelY = lowLevelPrice
+                            lowLabelY = lowLevelPrice + syminfo.mintick * labelOffsetY
                             lowAge = bar_index - line.get_x1(lowLineId) + 1
                             label.set_xy(lowLabelId, line.get_x2(lowLineId) + labelOffsetX, lowLabelY)
                             label.set_text(lowLabelId, str.tostring(lowAge))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update active-line progression to project 10 bars into the future on each new bar

## Exact changes
- in `barstate.isnew` active update loops only:
  - highs: `line.set_x2(highLineId, bar_index + 10)`
  - lows: `line.set_x2(lowLineId, bar_index + 10)`

## Intentionally unchanged
- line creation (`line.new`) still starts with `x2 = bar_index`
- sweep management still cuts lines at current sweep bar (`line.set_x2(..., bar_index)`)
- label X still follows right edge via `line.get_x2(lineId) - 2`

## Result
- non-swept lines maintain a forward projection of 10 bars ahead of the current bar
- swept lines remain cut at sweep point (no forward projection)

## Notes
- no PR template was found in this repository.
- no automated Pine runtime test harness exists in this repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba803d32-5d41-4c32-bfa4-0d50b53b8d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba803d32-5d41-4c32-bfa4-0d50b53b8d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

